### PR TITLE
more lenient regex to generate windows .def

### DIFF
--- a/obs-sys/build_win.rs
+++ b/obs-sys/build_win.rs
@@ -21,7 +21,7 @@ fn generate_def<P: AsRef<OsStr>, Q: AsRef<Path>>(
     let mut f = BufWriter::new(f);
     f.write(b"EXPORTS\r\n")?;
     let exports = String::from_utf8_lossy(&exports.stdout);
-    let pattern = Regex::new(r"(?im)^\s*\d+\s+[0-9a-f]+\s+[0-9a-f]+\s+(\S+)\r?$").unwrap();
+    let pattern = Regex::new(r"(?im)^\s*\d+\s+[0-9a-f]+\s+[0-9a-f]+\s+(\S+)(?:\s+=\s+\S+)?\r?$").unwrap();
     for export in pattern.captures_iter(&exports) {
         f.write_fmt(format_args!("{}\r\n", export.get(1).unwrap().as_str()))?;
     }


### PR DESCRIPTION
When compiling this on my Windows machine, the output of `dumpbin.exe /EXPORTS` does not quite match the regex used in *build_win.rs*. Mine outputs lines that look like

````
         10    9 0001C7B0 audio_output_disconnect = audio_output_disconnect
````

I've modified the regex to accept this, and it should continue to accept anything it accepted previously. With this change, I can get the bundled plugins to build without link errors.