### PR TITLE
Use an https URL for the obs-studio submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "obs-sys/obs"]
 	path = obs-sys/obs
-	url = git@github.com:obsproject/obs-studio.git
+	url = https://github.com/obsproject/obs-studio.git


### PR DESCRIPTION
Cloning over https is better because it doesn't rely on having a github
account (and associated ssh configuration)