### PR TITLE
very simple logic to search for libobs on MacOS

### DIFF
--- a/obs-sys/Cargo.toml
+++ b/obs-sys/Cargo.toml
@@ -14,3 +14,6 @@ bindgen = "0.53.1"
 cc = "1.0"
 regex = "1.0"
 winreg = "0.5"
+
+[target.'cfg(target_os = "macos")'.build-dependencies]
+shellexpand = "2.0"

--- a/obs-sys/build.rs
+++ b/obs-sys/build.rs
@@ -7,16 +7,25 @@ use std::path::PathBuf;
 #[cfg(windows)]
 mod build_win;
 
-#[cfg(windows)]
-use build_win::find_windows_obs_lib;
+#[cfg(target_os = "macos")]
+mod build_mac;
 
 fn main() {
     // Tell cargo to invalidate the built crate whenever the wrapper changes
     println!("cargo:rerun-if-changed=wrapper.h");
+
+    #[cfg(not(target_os = "macos"))]
     println!("cargo:rustc-link-lib=dylib=obs");
 
+    // mac OBS only ships with libobs.0.dylib for some reason
+    #[cfg(target_os = "macos")]
+    println!("cargo:rustc-link-lib=dylib=obs.0");
+
     #[cfg(windows)]
-    find_windows_obs_lib();
+    build_win::find_windows_obs_lib();
+
+    #[cfg(target_os = "macos")]
+    build_mac::find_mac_obs_lib();
 
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
 

--- a/obs-sys/build_mac.rs
+++ b/obs-sys/build_mac.rs
@@ -1,0 +1,26 @@
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+
+pub fn find_mac_obs_lib() {
+    if let Some(path) = env::var("LIBOBS_PATH").ok() {
+        println!("cargo:rustc-link-search=native={}", path);
+        return;
+    }
+
+    let candidates = [
+        PathBuf::from(&*shellexpand::tilde("~/Applications/OBS.app/Contents/MacOS")),
+        PathBuf::from("/Applications/OBS.app/Contents/MacOS"),
+    ];
+
+    for c in candidates.iter() {
+        if let Ok(meta) = fs::metadata(c.join("libobs.0.dylib")) {
+            if meta.is_file() {
+                println!("cargo:rustc-link-search=native={}", c.display());
+                return;
+            }
+        }
+    }
+
+    panic!("could not find libobs - install OBS or set LIBOBS_PATH");
+}


### PR DESCRIPTION
I've added a very simple search for OBS installations on MacOS. It looks for `OBS.app` in both `/Applications` and `~/Applications`, and can be overridden via `$LIBOBS_PATH` just like on Windows.

This is just enough to link correctly and produce loadable modules on *most* Macs with OBS installed.