### PR TITLE
Better property and data handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 Cargo.lock
+.vscode

--- a/obs-sys/generated/bindings.rs
+++ b/obs-sys/generated/bindings.rs
@@ -28,13 +28,13 @@ pub const __STDC_IEC_559_COMPLEX__: u32 = 1;
 pub const __STDC_ISO_10646__: u32 = 201706;
 pub const __GNU_LIBRARY__: u32 = 6;
 pub const __GLIBC__: u32 = 2;
-pub const __GLIBC_MINOR__: u32 = 31;
+pub const __GLIBC_MINOR__: u32 = 32;
 pub const _SYS_CDEFS_H: u32 = 1;
 pub const __glibc_c99_flexarr_available: u32 = 1;
 pub const __WORDSIZE: u32 = 64;
 pub const __WORDSIZE_TIME64_COMPAT32: u32 = 1;
 pub const __SYSCALL_WORDSIZE: u32 = 64;
-pub const __LONG_DOUBLE_USES_FLOAT128: u32 = 0;
+pub const __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI: u32 = 0;
 pub const __HAVE_GENERIC_SELECTION: u32 = 1;
 pub const __GLIBC_USE_LIB_EXT2: u32 = 0;
 pub const __GLIBC_USE_IEC_60559_BFP_EXT: u32 = 0;
@@ -49,6 +49,7 @@ pub const __OFF_T_MATCHES_OFF64_T: u32 = 1;
 pub const __INO_T_MATCHES_INO64_T: u32 = 1;
 pub const __RLIM_T_MATCHES_RLIM64_T: u32 = 1;
 pub const __STATFS_MATCHES_STATFS64: u32 = 1;
+pub const __KERNEL_OLD_TIMEVAL_MATCHES_TIMEVAL64: u32 = 1;
 pub const __FD_SETSIZE: u32 = 1024;
 pub const _BITS_TIME64_H: u32 = 1;
 pub const _BITS_WCHAR_H: u32 = 1;
@@ -115,7 +116,6 @@ pub const BYTE_ORDER: u32 = 1234;
 pub const _BITS_BYTESWAP_H: u32 = 1;
 pub const _BITS_UINTN_IDENTITY_H: u32 = 1;
 pub const _SYS_SELECT_H: u32 = 1;
-pub const __FD_ZERO_STOS: &'static [u8; 6usize] = b"stosq\0";
 pub const __sigset_t_defined: u32 = 1;
 pub const __timeval_defined: u32 = 1;
 pub const _STRUCT_TIMESPEC: u32 = 1;
@@ -588,6 +588,7 @@ pub type __id_t = ::std::os::raw::c_uint;
 pub type __time_t = ::std::os::raw::c_long;
 pub type __useconds_t = ::std::os::raw::c_uint;
 pub type __suseconds_t = ::std::os::raw::c_long;
+pub type __suseconds64_t = ::std::os::raw::c_long;
 pub type __daddr_t = ::std::os::raw::c_int;
 pub type __key_t = ::std::os::raw::c_int;
 pub type __clockid_t = ::std::os::raw::c_int;
@@ -1452,6 +1453,36 @@ impl Default for __pthread_cond_s {
     fn default() -> Self {
         unsafe { ::std::mem::zeroed() }
     }
+}
+pub type __tss_t = ::std::os::raw::c_uint;
+pub type __thrd_t = ::std::os::raw::c_ulong;
+#[repr(C)]
+#[derive(Debug, Default, Copy, Clone)]
+pub struct __once_flag {
+    pub __data: ::std::os::raw::c_int,
+}
+#[test]
+fn bindgen_test_layout___once_flag() {
+    assert_eq!(
+        ::std::mem::size_of::<__once_flag>(),
+        4usize,
+        concat!("Size of: ", stringify!(__once_flag))
+    );
+    assert_eq!(
+        ::std::mem::align_of::<__once_flag>(),
+        4usize,
+        concat!("Alignment of ", stringify!(__once_flag))
+    );
+    assert_eq!(
+        unsafe { &(*(::std::ptr::null::<__once_flag>())).__data as *const _ as usize },
+        0usize,
+        concat!(
+            "Offset of field: ",
+            stringify!(__once_flag),
+            "::",
+            stringify!(__data)
+        )
+    );
 }
 pub type pthread_t = ::std::os::raw::c_ulong;
 #[repr(C)]

--- a/plugins/rnnoise-denoiser-filter/src/lib.rs
+++ b/plugins/rnnoise-denoiser-filter/src/lib.rs
@@ -49,7 +49,7 @@ impl GetNameSource<Data> for RnnoiseDenoiserFilter {
 
 impl CreatableSource<Data> for RnnoiseDenoiserFilter {
     fn create(
-        _settings: &mut SettingsContext,
+        _settings: &mut DataObj,
         mut _source: SourceContext,
         context: &mut GlobalContext,
     ) -> Data {
@@ -73,11 +73,7 @@ impl CreatableSource<Data> for RnnoiseDenoiserFilter {
 }
 
 impl UpdateSource<Data> for RnnoiseDenoiserFilter {
-    fn update(
-        data: &mut Option<Data>,
-        _settings: &mut SettingsContext,
-        context: &mut GlobalContext,
-    ) {
+    fn update(data: &mut Option<Data>, _settings: &mut DataObj, context: &mut GlobalContext) {
         if let Some(data) = data {
             let sample_rate = context.with_audio(|audio| audio.output_sample_rate());
             data.sample_rate = sample_rate as f64;

--- a/plugins/scroll-focus-filter/src/lib.rs
+++ b/plugins/scroll-focus-filter/src/lib.rs
@@ -372,10 +372,8 @@ impl CreatableSource<Data> for ScrollFocusFilter {
 
 impl UpdateSource<Data> for ScrollFocusFilter {
     fn update(data: &mut Option<Data>, settings: &mut DataObj, _context: &mut GlobalContext) {
-        println!("up");
         if let Some(data) = data {
             if let Some(zoom) = settings.get::<f64, _>(obs_string!("zoom")) {
-                println!("{}", zoom);
                 data.from_zoom = data.current_zoom;
                 data.internal_zoom = 1. / zoom;
                 data.target_zoom = 1. / zoom;

--- a/plugins/scroll-focus-filter/src/lib.rs
+++ b/plugins/scroll-focus-filter/src/lib.rs
@@ -78,55 +78,63 @@ impl GetNameSource<Data> for ScrollFocusFilter {
 
 impl GetPropertiesSource<Data> for ScrollFocusFilter {
     fn get_properties(_data: &mut Option<Data>, properties: &mut Properties) {
-        properties.add_float_slider(
-            obs_string!("zoom"),
-            obs_string!("Amount to zoom in window"),
-            1.,
-            5.,
-            0.001,
-        );
-        properties.add_int(
-            obs_string!("screen_x"),
-            obs_string!("Offset relative to top left screen - x"),
-            0,
-            3840 * 3,
-            1,
-        );
-        properties.add_int(
-            obs_string!("screen_y"),
-            obs_string!("Offset relative to top left screen - y"),
-            0,
-            3840 * 3,
-            1,
-        );
-        properties.add_float_slider(
-            obs_string!("padding"),
-            obs_string!("Padding around each window"),
-            0.,
-            0.5,
-            0.001,
-        );
-        properties.add_int(
-            obs_string!("screen_width"),
-            obs_string!("Screen width"),
-            1,
-            3840 * 3,
-            1,
-        );
-        properties.add_int(
-            obs_string!("screen_height"),
-            obs_string!("Screen height"),
-            1,
-            3840 * 3,
-            1,
-        );
-        properties.add_float(
-            obs_string!("animation_time"),
-            obs_string!("Animation Time (s)"),
-            0.3,
-            10.,
-            0.001,
-        );
+        properties
+            .add_float(
+                obs_string!("zoom"),
+                obs_string!("Amount to zoom in window"),
+                1.,
+                5.,
+                0.001,
+                true,
+            )
+            .add_int(
+                obs_string!("screen_x"),
+                obs_string!("Offset relative to top left screen - x"),
+                0,
+                3840 * 3,
+                1,
+                false,
+            )
+            .add_int(
+                obs_string!("screen_y"),
+                obs_string!("Offset relative to top left screen - y"),
+                0,
+                3840 * 3,
+                1,
+                false,
+            )
+            .add_float(
+                obs_string!("padding"),
+                obs_string!("Padding around each window"),
+                0.,
+                0.5,
+                0.001,
+                true,
+            )
+            .add_int(
+                obs_string!("screen_width"),
+                obs_string!("Screen width"),
+                1,
+                3840 * 3,
+                1,
+                false,
+            )
+            .add_int(
+                obs_string!("screen_height"),
+                obs_string!("Screen height"),
+                1,
+                3840 * 3,
+                1,
+                false,
+            )
+            .add_float(
+                obs_string!("animation_time"),
+                obs_string!("Animation Time (s)"),
+                0.3,
+                10.,
+                0.001,
+                false,
+            );
     }
 }
 
@@ -261,7 +269,7 @@ impl VideoRenderSource<Data> for ScrollFocusFilter {
 
 impl CreatableSource<Data> for ScrollFocusFilter {
     fn create(
-        settings: &mut SettingsContext,
+        settings: &mut DataObj,
         mut source: SourceContext,
         _context: &mut GlobalContext,
     ) -> Data {
@@ -284,23 +292,17 @@ impl CreatableSource<Data> for ScrollFocusFilter {
             effect.get_effect_param_by_name(obs_string!("base_dimension_i")),
             effect.get_effect_param_by_name(obs_string!("mul_val")),
         ) {
-            let zoom = 1. / settings.get_float(obs_string!("zoom")).unwrap_or(1.);
+            let zoom = 1. / settings.get(obs_string!("zoom")).unwrap_or(1.);
 
             let sampler = GraphicsSamplerState::from(GraphicsSamplerInfo::default());
 
-            let screen_width = settings
-                .get_int(obs_string!("screen_width"))
-                .unwrap_or(1920) as u32;
-            let screen_height = settings
-                .get_int(obs_string!("screen_height"))
-                .unwrap_or(1080) as u32;
+            let screen_width = settings.get(obs_string!("screen_width")).unwrap_or(1920) as u32;
+            let screen_height = settings.get(obs_string!("screen_height")).unwrap_or(1080) as u32;
 
-            let screen_x = settings.get_int(obs_string!("screen_x")).unwrap_or(0) as u32;
-            let screen_y = settings.get_int(obs_string!("screen_y")).unwrap_or(0) as u32;
+            let screen_x = settings.get(obs_string!("screen_x")).unwrap_or(0) as u32;
+            let screen_y = settings.get(obs_string!("screen_y")).unwrap_or(0) as u32;
 
-            let animation_time = settings
-                .get_float(obs_string!("animation_time"))
-                .unwrap_or(0.3);
+            let animation_time = settings.get(obs_string!("animation_time")).unwrap_or(0.3);
 
             let (send_filter, receive_filter) = unbounded::<FilterMessage>();
             let (send_server, receive_server) = unbounded::<ServerMessage>();
@@ -369,37 +371,35 @@ impl CreatableSource<Data> for ScrollFocusFilter {
 }
 
 impl UpdateSource<Data> for ScrollFocusFilter {
-    fn update(
-        data: &mut Option<Data>,
-        settings: &mut SettingsContext,
-        _context: &mut GlobalContext,
-    ) {
+    fn update(data: &mut Option<Data>, settings: &mut DataObj, _context: &mut GlobalContext) {
+        println!("up");
         if let Some(data) = data {
-            if let Some(zoom) = settings.get_float(obs_string!("zoom")) {
+            if let Some(zoom) = settings.get::<f64, _>(obs_string!("zoom")) {
+                println!("{}", zoom);
                 data.from_zoom = data.current_zoom;
                 data.internal_zoom = 1. / zoom;
                 data.target_zoom = 1. / zoom;
             }
 
-            if let Some(screen_width) = settings.get_int(obs_string!("screen_width")) {
+            if let Some(screen_width) = settings.get::<i64, _>(obs_string!("screen_width")) {
                 data.screen_width = screen_width as u32;
             }
 
-            if let Some(padding) = settings.get_float(obs_string!("padding")) {
+            if let Some(padding) = settings.get(obs_string!("padding")) {
                 data.padding = padding;
             }
 
-            if let Some(animation_time) = settings.get_float(obs_string!("animation_time")) {
+            if let Some(animation_time) = settings.get(obs_string!("animation_time")) {
                 data.animation_time = animation_time;
             }
 
-            if let Some(screen_height) = settings.get_int(obs_string!("screen_height")) {
+            if let Some(screen_height) = settings.get::<i64, _>(obs_string!("screen_height")) {
                 data.screen_height = screen_height as u32;
             }
-            if let Some(screen_x) = settings.get_int(obs_string!("screen_x")) {
+            if let Some(screen_x) = settings.get::<i64, _>(obs_string!("screen_x")) {
                 data.screen_x = screen_x as u32;
             }
-            if let Some(screen_y) = settings.get_int(obs_string!("screen_y")) {
+            if let Some(screen_y) = settings.get::<i64, _>(obs_string!("screen_y")) {
                 data.screen_y = screen_y as u32;
             }
         }

--- a/src/data.rs
+++ b/src/data.rs
@@ -84,7 +84,7 @@ impl FromDataItem for f64 {
 
 impl FromDataItem for bool {
     fn typ() -> DataType {
-        DataType::Int
+        DataType::Boolean
     }
     unsafe fn from_item_unchecked(item: *mut obs_data_item_t) -> Self {
         obs_data_item_get_bool(item)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,8 @@ pub mod source;
 /// String macros
 pub mod string;
 
+pub mod data;
+
 mod native_enum;
 
 /// Re-exports of a bunch of popular tools
@@ -133,4 +135,5 @@ pub mod prelude {
     pub use crate::module::*;
     pub use crate::source::context::*;
     pub use crate::string::*;
+    pub use crate::data::{DataObj, DataArray, FromDataItem};
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,6 +126,8 @@ pub mod source;
 /// String macros
 pub mod string;
 
+mod native_enum;
+
 /// Re-exports of a bunch of popular tools
 pub mod prelude {
     pub use crate::module::*;

--- a/src/native_enum.rs
+++ b/src/native_enum.rs
@@ -1,0 +1,53 @@
+#[derive(Debug)]
+pub struct NativeParsingError {
+    struct_name: &'static str,
+    value: u32,
+}
+
+impl NativeParsingError {
+    pub(crate) fn new(struct_name: &'static str, value: u32) -> Self {
+        Self { struct_name, value }
+    }
+}
+
+impl std::fmt::Display for NativeParsingError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "Failed to convert native value {} into {}",
+            self.value, self.struct_name
+        )
+    }
+}
+
+impl std::error::Error for NativeParsingError {}
+
+#[macro_export]
+macro_rules! native_enum {
+    ($name:ident,$native_name:ident { $($rust:ident => $native:ident),* }) => {
+        paste::item! {
+        #[derive(Debug, Clone, Copy)]
+            pub enum $name {
+                $($rust),*
+            }
+
+            impl Into<$native_name> for $name {
+                fn into(self) -> obs_text_type {
+                    match self {
+                        $(Self::$rust => [<$native_name _ $native>]),*
+                    }
+                }
+            }
+
+            impl std::convert::TryFrom<$native_name> for $name {
+                type Error = crate::native_enum::NativeParsingError;
+                fn try_from(value: $native_name) -> Result<Self, Self::Error> {
+                    match value {
+                        $([<$native_name _ $native>] => Ok(Self::$rust)),*,
+                        _ => Err(crate::native_enum::NativeParsingError::new(stringify!($name), value))
+                    }
+                }
+            }
+        }
+    };
+}

--- a/src/source/data.rs
+++ b/src/source/data.rs
@@ -1,0 +1,188 @@
+use std::{
+    borrow::Cow,
+    ffi::{CStr, CString},
+    marker::PhantomData,
+};
+
+use obs_sys::{
+    obs_data_array_count, obs_data_array_item, obs_data_array_release, obs_data_array_t,
+    obs_data_item_byname, obs_data_item_get_array, obs_data_item_get_bool,
+    obs_data_item_get_double, obs_data_item_get_int, obs_data_item_get_obj,
+    obs_data_item_get_string, obs_data_item_gettype, obs_data_item_numtype, obs_data_item_release,
+    obs_data_item_t, obs_data_number_type, obs_data_number_type_OBS_DATA_NUM_DOUBLE,
+    obs_data_number_type_OBS_DATA_NUM_INT, obs_data_release, obs_data_t, obs_data_type,
+    obs_data_type_OBS_DATA_ARRAY, obs_data_type_OBS_DATA_BOOLEAN, obs_data_type_OBS_DATA_NUMBER,
+    obs_data_type_OBS_DATA_OBJECT, obs_data_type_OBS_DATA_STRING, size_t,
+};
+
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
+pub enum DataType {
+    String,
+    Int,
+    Double,
+    Boolean,
+    /// Map container
+    Object,
+    /// Array container
+    Array,
+}
+
+impl DataType {
+    pub fn new(typ: obs_data_type, numtyp: obs_data_number_type) -> Self {
+        match typ {
+            obs_data_type_OBS_DATA_STRING => Self::String,
+            obs_data_type_OBS_DATA_NUMBER => match numtyp {
+                obs_data_number_type_OBS_DATA_NUM_INT => Self::Int,
+                obs_data_number_type_OBS_DATA_NUM_DOUBLE => Self::Double,
+                _ => unimplemented!(),
+            },
+            obs_data_type_OBS_DATA_BOOLEAN => Self::Boolean,
+            obs_data_type_OBS_DATA_OBJECT => Self::Object,
+            obs_data_type_OBS_DATA_ARRAY => Self::Array,
+            _ => unimplemented!(),
+        }
+    }
+
+    unsafe fn from_item(item_ptr: *mut obs_data_item_t) -> Self {
+        let typ = obs_data_item_gettype(item_ptr);
+        let numtyp = obs_data_item_numtype(item_ptr);
+        Self::new(typ, numtyp)
+    }
+}
+
+pub trait FromDataItem {
+    fn typ() -> DataType;
+    unsafe fn from_item_unchecked(item: *mut obs_data_item_t) -> Self;
+}
+
+impl FromDataItem for Cow<'_, str> {
+    fn typ() -> DataType {
+        DataType::String
+    }
+    unsafe fn from_item_unchecked(item: *mut obs_data_item_t) -> Self {
+        let ptr = obs_data_item_get_string(item);
+        CStr::from_ptr(ptr).to_string_lossy()
+    }
+}
+
+impl FromDataItem for i64 {
+    fn typ() -> DataType {
+        DataType::Int
+    }
+    unsafe fn from_item_unchecked(item: *mut obs_data_item_t) -> Self {
+        obs_data_item_get_int(item)
+    }
+}
+
+impl FromDataItem for f64 {
+    fn typ() -> DataType {
+        DataType::Int
+    }
+    unsafe fn from_item_unchecked(item: *mut obs_data_item_t) -> Self {
+        obs_data_item_get_double(item)
+    }
+}
+
+impl FromDataItem for bool {
+    fn typ() -> DataType {
+        DataType::Int
+    }
+    unsafe fn from_item_unchecked(item: *mut obs_data_item_t) -> Self {
+        obs_data_item_get_bool(item)
+    }
+}
+
+impl FromDataItem for DataObj<'_> {
+    fn typ() -> DataType {
+        DataType::Object
+    }
+    unsafe fn from_item_unchecked(item: *mut obs_data_item_t) -> Self {
+        Self::new_unchecked(obs_data_item_get_obj(item))
+    }
+}
+
+impl FromDataItem for DataArray<'_> {
+    fn typ() -> DataType {
+        DataType::Array
+    }
+    unsafe fn from_item_unchecked(item: *mut obs_data_item_t) -> Self {
+        Self::new_unchecked(obs_data_item_get_array(item))
+    }
+}
+
+/// A smart pointer to `obs_data_t`
+pub struct DataObj<'parent> {
+    raw: *mut obs_data_t,
+    _parent: PhantomData<&'parent DataObj<'parent>>,
+}
+
+impl DataObj<'_> {
+    unsafe fn new_unchecked(raw: *mut obs_data_t) -> Self {
+        Self {
+            raw,
+            _parent: PhantomData,
+        }
+    }
+
+    pub fn get<T: FromDataItem>(&self, name: &str) -> Option<T> {
+        let name = CString::new(name).unwrap();
+        let mut item_ptr = unsafe { obs_data_item_byname(self.raw, name.as_ptr()) };
+        if item_ptr.is_null() {
+            return None;
+        }
+        // Release it immediately since it is also referenced by this object.
+        unsafe {
+            obs_data_item_release(&mut item_ptr);
+        }
+        assert!(!item_ptr.is_null()); // We should not be the last holder
+
+        let typ = unsafe { DataType::from_item(item_ptr) };
+
+        if typ == T::typ() {
+            Some(unsafe { T::from_item_unchecked(item_ptr) })
+        } else {
+            None
+        }
+    }
+}
+
+impl Drop for DataObj<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            obs_data_release(self.raw);
+        }
+    }
+}
+
+pub struct DataArray<'parent> {
+    raw: *mut obs_data_array_t,
+    _parent: PhantomData<&'parent DataArray<'parent>>,
+}
+
+impl DataArray<'_> {
+    unsafe fn new_unchecked(raw: *mut obs_data_array_t) -> Self {
+        Self {
+            raw,
+            _parent: PhantomData,
+        }
+    }
+    pub fn len(&self) -> usize {
+        unsafe { obs_data_array_count(self.raw) as usize }
+    }
+    pub fn get(&self, index: usize) -> Option<DataObj> {
+        let ptr = unsafe { obs_data_array_item(self.raw, index as size_t) };
+        if ptr.is_null() {
+            None
+        } else {
+            Some(unsafe { DataObj::new_unchecked(ptr) })
+        }
+    }
+}
+
+impl Drop for DataArray<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            obs_data_array_release(self.raw);
+        }
+    }
+}

--- a/src/source/ffi.rs
+++ b/src/source/ffi.rs
@@ -1,9 +1,11 @@
 use super::audio::AudioDataContext;
 use super::context::{GlobalContext, VideoRenderContext};
-use super::properties::{Properties, Property, SettingsContext};
+use super::properties::Properties;
 use super::traits::*;
 use super::{EnumActiveContext, EnumAllContext, SourceContext};
+use crate::data::DataObj;
 use std::ffi::c_void;
+use std::mem::forget;
 use std::os::raw::c_char;
 
 use obs_sys::{
@@ -13,24 +15,17 @@ use obs_sys::{
 
 struct DataWrapper<D> {
     data: Option<D>,
-    properties: Vec<Property>,
 }
 
 impl<D> Default for DataWrapper<D> {
     fn default() -> Self {
-        Self {
-            data: None,
-            properties: vec![],
-        }
+        Self { data: None }
     }
 }
 
 impl<D> From<D> for DataWrapper<D> {
     fn from(data: D) -> Self {
-        Self {
-            data: Some(data),
-            properties: vec![],
-        }
+        Self { data: Some(data) }
     }
 }
 
@@ -63,15 +58,14 @@ pub unsafe extern "C" fn create<D, F: CreatableSource<D>>(
     source: *mut obs_source_t,
 ) -> *mut c_void {
     let mut wrapper = DataWrapper::default();
-    let mut settings = SettingsContext::from_raw(settings, &wrapper.properties);
+    let mut settings = DataObj::new_unchecked(settings);
 
     let source = SourceContext { source };
     let mut global = GlobalContext::default();
 
     let data = F::create(&mut settings, source, &mut global);
-
     wrapper.data = Some(data);
-
+    forget(settings);
     Box::into_raw(Box::new(wrapper)) as *mut c_void
 }
 
@@ -86,8 +80,9 @@ pub unsafe extern "C" fn update<D, F: UpdateSource<D>>(
 ) {
     let mut global = GlobalContext::default();
     let data: &mut DataWrapper<D> = &mut *(data as *mut DataWrapper<D>);
-    let mut settings = SettingsContext::from_raw(settings, &data.properties);
+    let mut settings = DataObj::new_unchecked(settings);
     F::update(&mut data.data, &mut settings, &mut global);
+    forget(settings);
 }
 
 pub unsafe extern "C" fn video_render<D, F: VideoRenderSource<D>>(
@@ -120,7 +115,7 @@ pub unsafe extern "C" fn get_properties<D, F: GetPropertiesSource<D>>(
 ) -> *mut obs_properties {
     let wrapper: &mut DataWrapper<D> = &mut *(data as *mut DataWrapper<D>);
 
-    let mut properties = Properties::from_raw(obs_properties_create(), &mut wrapper.properties);
+    let mut properties = Properties::from_raw(obs_properties_create());
 
     F::get_properties(&mut wrapper.data, &mut properties);
 

--- a/src/source/ffi.rs
+++ b/src/source/ffi.rs
@@ -173,3 +173,9 @@ pub unsafe extern "C" fn filter_audio<D, F: FilterAudioSource<D>>(
     F::filter_audio(&mut wrapper.data, &mut context);
     audio
 }
+
+pub unsafe extern "C" fn get_defaults<D, F: GetDefaultsSource<D>>(settings: *mut obs_data_t) {
+    let mut settings = DataObj::new_unchecked(settings);
+    F::get_defaults(&mut settings);
+    forget(settings);
+}

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -7,7 +7,6 @@ pub mod context;
 mod ffi;
 pub mod properties;
 pub mod traits;
-pub mod data;
 
 pub use context::*;
 pub use properties::*;
@@ -29,6 +28,7 @@ use super::{
     },
     string::ObsString,
 };
+use crate::data::DataObj;
 
 use std::marker::PhantomData;
 
@@ -165,7 +165,7 @@ impl SourceContext {
     }
 
     /// Update the source settings based on a settings context.
-    pub fn update_source_settings(&mut self, settings: &SettingsContext) {
+    pub fn update_source_settings(&mut self, settings: &DataObj) {
         unsafe {
             obs_source_update(self.source, settings.as_raw());
         }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -7,6 +7,7 @@ pub mod context;
 mod ffi;
 pub mod properties;
 pub mod traits;
+pub mod data;
 
 pub use context::*;
 pub use properties::*;

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -267,4 +267,5 @@ impl_source_builder! {
     transition_stop => TransitionStopSource
     video_tick => VideoTickSource
     filter_audio => FilterAudioSource
+    get_defaults => GetDefaultsSource
 }

--- a/src/source/properties.rs
+++ b/src/source/properties.rs
@@ -1,11 +1,64 @@
 use super::ObsString;
 use obs_sys::{
-    obs_data_get_double, obs_data_get_int, obs_data_get_json, obs_data_t, obs_properties_add_float,
-    obs_properties_add_float_slider, obs_properties_add_int, obs_properties_t,
+    obs_combo_format, obs_combo_format_OBS_COMBO_FORMAT_FLOAT,
+    obs_combo_format_OBS_COMBO_FORMAT_INT, obs_combo_format_OBS_COMBO_FORMAT_INVALID,
+    obs_combo_format_OBS_COMBO_FORMAT_STRING, obs_combo_type,
+    obs_combo_type_OBS_COMBO_TYPE_EDITABLE, obs_combo_type_OBS_COMBO_TYPE_INVALID,
+    obs_combo_type_OBS_COMBO_TYPE_LIST, obs_data_get_double, obs_data_get_int, obs_data_get_json,
+     obs_data_t, obs_editable_list_type,
+    obs_editable_list_type_OBS_EDITABLE_LIST_TYPE_FILES,
+    obs_editable_list_type_OBS_EDITABLE_LIST_TYPE_FILES_AND_URLS,
+    obs_editable_list_type_OBS_EDITABLE_LIST_TYPE_STRINGS, obs_path_type,
+    obs_path_type_OBS_PATH_DIRECTORY, obs_path_type_OBS_PATH_FILE,
+    obs_path_type_OBS_PATH_FILE_SAVE, obs_properties_add_bool, obs_properties_add_color,
+    obs_properties_add_editable_list, obs_properties_add_float, obs_properties_add_float_slider,
+    obs_properties_add_font, obs_properties_add_int, obs_properties_add_list,
+    obs_properties_add_path, obs_properties_add_text, obs_properties_t,
+    obs_property_list_add_float, obs_property_list_add_int, obs_property_list_add_string,
+    obs_property_list_insert_float, obs_property_list_insert_int, obs_property_list_insert_string,
+    obs_property_list_item_disable, obs_property_list_item_remove, obs_property_t, obs_text_type,
+    obs_text_type_OBS_TEXT_DEFAULT, obs_text_type_OBS_TEXT_MULTILINE,
+    obs_text_type_OBS_TEXT_PASSWORD, size_t,
 };
-use std::ffi::CStr;
+use crate::native_enum;
+
+use std::{
+    ffi::{CStr, CString},
+    marker::PhantomData,
+};
 
 use serde_json::Value;
+
+native_enum!(TextType, obs_text_type {
+    Default => OBS_TEXT_DEFAULT,
+    Password => OBS_TEXT_PASSWORD,
+    Multiline => OBS_TEXT_MULTILINE
+});
+
+native_enum!(PathType, obs_path_type {
+    File => OBS_PATH_FILE,
+    FileSave => OBS_PATH_FILE_SAVE,
+    Directory => OBS_PATH_DIRECTORY
+});
+
+native_enum!(ComboFormat, obs_combo_format {
+    Invalid => OBS_COMBO_FORMAT_INVALID,
+    Int => OBS_COMBO_FORMAT_INT,
+    Float => OBS_COMBO_FORMAT_FLOAT,
+    String => OBS_COMBO_FORMAT_STRING
+});
+
+native_enum!(ComboType, obs_combo_type {
+    Invalid => OBS_COMBO_TYPE_INVALID,
+    Editable => OBS_COMBO_TYPE_EDITABLE,
+    List => OBS_COMBO_TYPE_LIST
+});
+
+native_enum!(EditableListType, obs_editable_list_type {
+    Strings => OBS_EDITABLE_LIST_TYPE_STRINGS,
+    Files => OBS_EDITABLE_LIST_TYPE_FILES,
+    FilesAndUrls => OBS_EDITABLE_LIST_TYPE_FILES_AND_URLS
+});
 
 pub struct ParamBuilder {}
 
@@ -114,6 +167,237 @@ impl<'a> Properties<'a> {
             );
         }
         self
+    }
+
+    pub fn add_bool(&mut self, name: ObsString, description: ObsString) -> &mut Self {
+        unsafe {
+            obs_properties_add_bool(self.pointer, name.as_ptr(), description.as_ptr());
+        }
+        self
+    }
+
+    pub fn add_text(
+        &mut self,
+        name: ObsString,
+        description: ObsString,
+        typ: TextType,
+    ) -> &mut Self {
+        unsafe {
+            obs_properties_add_text(
+                self.pointer,
+                name.as_ptr(),
+                description.as_ptr(),
+                typ.into(),
+            );
+        }
+        self
+    }
+
+    /// Adds a 'path' property.  Can be a directory or a file.
+    ///
+    /// If target is a file path, the filters should be this format, separated by
+    /// double semi-colens, and extensions separated by space:
+    ///
+    /// "Example types 1 and 2 (*.ex1 *.ex2);;Example type 3 (*.ex3)"
+    ///
+    /// Arguments
+    /// *  `props`: Properties object
+    /// *  `name`: Settings name
+    /// *  `description`: Description (display name) of the property
+    /// *  `type`: Type of path (directory or file)
+    /// *  `filter`: If type is a file path, then describes the file filter
+    ///              that the user can browse.  Items are separated via
+    ///              double semi-colens.  If multiple file types in a
+    ///              filter, separate with space.
+    pub fn add_path(
+        &mut self,
+        name: ObsString,
+        description: ObsString,
+        typ: PathType,
+        filter: ObsString,
+        default_path: &str,
+    ) -> &mut Self {
+        let path = CString::new(default_path).unwrap();
+        unsafe {
+            obs_properties_add_path(
+                self.pointer,
+                name.as_ptr(),
+                description.as_ptr(),
+                typ.into(),
+                filter.as_ptr(),
+                path.as_ptr(),
+            );
+        }
+        self
+    }
+
+    pub fn add_list<T: ListType>(
+        &mut self,
+        name: ObsString,
+        description: ObsString,
+        editable: bool,
+    ) -> ListProp<T> {
+        unsafe {
+            let raw = obs_properties_add_list(
+                self.pointer,
+                name.as_ptr(),
+                description.as_ptr(),
+                if editable {
+                    ComboType::Editable
+                } else {
+                    ComboType::List
+                }
+                .into(),
+                T::format().into(),
+            );
+            ListProp::new_unchecked(raw)
+        }
+    }
+
+    pub fn add_color(&mut self, name: ObsString, description: ObsString) -> &mut Self {
+        unsafe {
+            obs_properties_add_color(self.pointer, name.as_ptr(), description.as_ptr());
+        }
+        self
+    }
+
+    /// Adds a font selection property.
+    ///
+    /// A font is an obs_data sub-object which contains the following items:
+    ///   face:   face name string
+    ///
+    ///   style:  style name string
+    ///
+    ///   size:   size integer
+    ///
+    ///   flags:  font flags integer (OBS_FONT_* defined above)
+    pub fn add_font(&mut self, name: ObsString, description: ObsString) -> &mut Self {
+        unsafe {
+            obs_properties_add_font(self.pointer, name.as_ptr(), description.as_ptr());
+        }
+        self
+    }
+
+    pub fn add_editable_list(
+        &mut self,
+        name: ObsString,
+        description: ObsString,
+        typ: EditableListType,
+        filter: ObsString,
+        default_path: &str,
+    ) -> &mut Self {
+        let path = CString::new(default_path).unwrap();
+        unsafe {
+            obs_properties_add_editable_list(
+                self.pointer,
+                name.as_ptr(),
+                description.as_ptr(),
+                typ.into(),
+                filter.as_ptr(),
+                path.as_ptr(),
+            );
+        }
+        self
+    }
+}
+
+pub struct ListProp<'props, T> {
+    raw: *mut obs_property_t,
+    _props: PhantomData<&'props mut Properties<'props>>,
+    _type: PhantomData<T>,
+}
+
+impl<T: ListType> ListProp<'_, T> {
+    unsafe fn new_unchecked(raw: *mut obs_property_t) -> Self {
+        Self {
+            raw,
+            _props: PhantomData,
+            _type: PhantomData,
+        }
+    }
+
+    pub fn push(&mut self, name: &str, value: T) {
+        let name = CString::new(name).unwrap();
+        value.push_into(self.raw, name);
+    }
+
+    pub fn insert(&mut self, index: usize, name: &str, value: T) {
+        let name = CString::new(name).unwrap();
+        value.insert_into(self.raw, name, index);
+    }
+
+    pub fn remove(&mut self, index: usize) {
+        unsafe {
+            obs_property_list_item_remove(self.raw, index as size_t);
+        }
+    }
+
+    pub fn disable(&mut self, index: usize, disabled: bool) {
+        unsafe {
+            obs_property_list_item_disable(self.raw, index as size_t, disabled);
+        }
+    }
+}
+
+pub trait ListType {
+    fn format() -> ComboFormat;
+    fn push_into(self, ptr: *mut obs_property_t, name: CString);
+    fn insert_into(self, ptr: *mut obs_property_t, name: CString, index: usize);
+}
+
+impl ListType for &str {
+    fn format() -> ComboFormat {
+        ComboFormat::String
+    }
+
+    fn push_into(self, ptr: *mut obs_property_t, name: CString) {
+        let value = CString::new(self).unwrap();
+        unsafe {
+            obs_property_list_add_string(ptr, name.as_ptr(), value.as_ptr());
+        }
+    }
+
+    fn insert_into(self, ptr: *mut obs_property_t, name: CString, index: usize) {
+        let value = CString::new(self).unwrap();
+        unsafe {
+            obs_property_list_insert_string(ptr, index as size_t, name.as_ptr(), value.as_ptr());
+        }
+    }
+}
+
+impl ListType for i64 {
+    fn format() -> ComboFormat {
+        ComboFormat::Int
+    }
+
+    fn push_into(self, ptr: *mut obs_property_t, name: CString) {
+        unsafe {
+            obs_property_list_add_int(ptr, name.as_ptr(), self);
+        }
+    }
+
+    fn insert_into(self, ptr: *mut obs_property_t, name: CString, index: usize) {
+        unsafe {
+            obs_property_list_insert_int(ptr, index as size_t, name.as_ptr(), self);
+        }
+    }
+}
+
+impl ListType for f64 {
+    fn format() -> ComboFormat {
+        ComboFormat::Float
+    }
+
+    fn push_into(self, ptr: *mut obs_property_t, name: CString) {
+        unsafe {
+            obs_property_list_add_float(ptr, name.as_ptr(), self);
+        }
+    }
+
+    fn insert_into(self, ptr: *mut obs_property_t, name: CString, index: usize) {
+        unsafe {
+            obs_property_list_insert_float(ptr, index as size_t, name.as_ptr(), self);
+        }
     }
 }
 

--- a/src/source/traits.rs
+++ b/src/source/traits.rs
@@ -70,3 +70,7 @@ pub trait TransitionStopSource<D> {
 pub trait FilterAudioSource<D> {
     fn filter_audio(data: &mut Option<D>, audio: &mut AudioDataContext);
 }
+
+pub trait GetDefaultsSource<D> {
+    fn get_defaults(settings: &mut DataObj);
+}

--- a/src/source/traits.rs
+++ b/src/source/traits.rs
@@ -1,6 +1,7 @@
 use super::audio::AudioDataContext;
 use super::context::{GlobalContext, VideoRenderContext};
-use super::properties::{Properties, SettingsContext};
+use super::properties::Properties;
+use crate::data::DataObj;
 use super::{EnumActiveContext, EnumAllContext, SourceContext, SourceType};
 
 use crate::string::ObsString;
@@ -23,11 +24,11 @@ pub trait GetHeightSource<D> {
 }
 
 pub trait CreatableSource<D> {
-    fn create(settings: &mut SettingsContext, source: SourceContext, context: &mut GlobalContext) -> D;
+    fn create(settings: &mut DataObj, source: SourceContext, context: &mut GlobalContext) -> D;
 }
 
 pub trait UpdateSource<D> {
-    fn update(data: &mut Option<D>, settings: &mut SettingsContext, context: &mut GlobalContext);
+    fn update(data: &mut Option<D>, settings: &mut DataObj, context: &mut GlobalContext);
 }
 
 pub trait VideoRenderSource<D> {


### PR DESCRIPTION
As for getting the properties, we might be better off with a Serde deserializer, but doing so makes it difficult to, say, set the default values.

The new settings handling system makes full use of Rust's trait system and type inferencing capabilities, which makes it possible to use one function to handle everything.

I didn't test the rnnoise filter since my PC has no sound I/O anyway, but the `scroll-focus-filter` works after modification on my Linux box.