### PR TITLE
Use a standard logging interface

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ members = [
 obs-sys = { path = "./obs-sys", version = "0.2.0" }
 serde_json = "1.0.48"
 paste = "0.1.7"
+log = "0.4.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -117,7 +117,7 @@ pub use obs_sys;
 
 /// Tools required for manipulating graphics in OBS
 pub mod graphics;
-/// Methods for logging to OBS console
+/// Logger for logging to OBS console
 pub mod log;
 /// Tools for creating modules
 pub mod module;

--- a/src/log.rs
+++ b/src/log.rs
@@ -12,6 +12,14 @@ use obs_sys::{blog, LOG_DEBUG, LOG_ERROR, LOG_INFO, LOG_WARNING};
 /// You can also use any other logger implementation, but we recommend this since
 /// OBS also writes everything in its logging system to a file, which can be viewed
 /// if there is a problem and OBS is not started from a console.
+///
+/// # Examples
+///
+/// A new logger with default settings.
+///
+/// ```no_run
+/// let _ = Logger::new().init();
+/// ```
 pub struct Logger {
     max_level: LevelFilter,
     promote_debug: bool,
@@ -34,6 +42,8 @@ impl Logger {
         Self::default()
     }
 
+    /// Initializes this logger, setting this as the global logger. This MUST be called to be effective.
+    /// This may fail if there is already a logger.
     pub fn init(self) -> Result<(), SetLoggerError> {
         log::set_max_level(self.max_level);
         log::set_boxed_logger(Box::new(self))?;

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,26 +1,109 @@
-#[macro_export]
-macro_rules! obs_log {
-        ($level:expr, $($arg:tt)*) => (unsafe {
-            $crate::obs_sys::blog($level, format!("{}", format_args!($($arg)*)).as_ptr() as *const std::os::raw::c_char)
-        });
+use std::os::raw::c_char;
+
+use log::{Level, LevelFilter, Log, Metadata, Record, SetLoggerError};
+use obs_sys::{blog, LOG_DEBUG, LOG_ERROR, LOG_INFO, LOG_WARNING};
+
+/// A logger that plugs into OBS's logging system.
+///
+/// Since OBS only has 4 logging levels and the lowest level is
+/// only enabled in debug builds of OBS, this logger provides a option
+/// to promote lower-level logs as `info`.
+///
+/// You can also use any other logger implementation, but we recommend this since
+/// OBS also writes everything in its logging system to a file, which can be viewed
+/// if there is a problem and OBS is not started from a console.
+pub struct Logger {
+    max_level: LevelFilter,
+    promote_debug: bool,
+}
+
+impl Default for Logger {
+    fn default() -> Self {
+        Self {
+            max_level: LevelFilter::Info,
+            promote_debug: false,
+        }
+    }
+}
+
+impl Logger {
+    /// Creates a new logger with default levle set to [`Level::Trace`] and does
+    /// not promote debug logs.
+    #[must_use = "You must call init() to begin logging"]
+    pub fn new() -> Self {
+        Self::default()
     }
 
-#[macro_export]
-macro_rules! debug {
-        ($($arg:tt)*) => ($crate::obs_log!(400, $($arg)*));
+    pub fn init(self) -> Result<(), SetLoggerError> {
+        log::set_max_level(self.max_level);
+        log::set_boxed_logger(Box::new(self))?;
+        Ok(())
     }
 
-#[macro_export]
-macro_rules! info {
-        ($($arg:tt)*) => ($crate::obs_log!(300, $($arg)*));
+    /// Sets whether to promote [`Level::Debug`] and [`Level::Trace`] logs.
+    #[must_use = "You must call init() to begin logging"]
+    pub fn with_promote_debug(mut self, promote_debug: bool) -> Self {
+        self.promote_debug = promote_debug;
+        self
     }
 
-#[macro_export]
-macro_rules! warning {
-        ($($arg:tt)*) => ($crate::obs_log!(200, $($arg)*));
+    /// Sets the maximum logging level.
+    #[must_use = "You must call init() to begin logging"]
+    pub fn with_max_level(mut self, max_level: LevelFilter) -> Self {
+        self.max_level = max_level;
+        self
+    }
+}
+
+impl Log for Logger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        metadata.level() >= self.max_level
     }
 
-#[macro_export]
-macro_rules! error {
-        ($($arg:tt)*) => ($crate::obs_log!(100, $($arg)*));
+    fn log(&self, record: &Record) {
+        if !self.enabled(record.metadata()) {
+            return;
+        }
+        let level = record.level();
+        let native_level = to_native_level(level, self.promote_debug);
+        let target = if !record.target().is_empty() {
+            record.target()
+        } else {
+            record.module_path().unwrap_or_default()
+        };
+
+        let line = if self.promote_debug && level <= Level::Debug {
+            format!("({}) [{}] {}\0", level, target, record.args())
+        } else {
+            format!("[{}] {}\0", target, record.args())
+        };
+
+        unsafe {
+            blog(
+                native_level as i32,
+                "%s\0".as_ptr() as *const c_char,
+                line.as_ptr() as *const c_char,
+            );
+        }
     }
+
+    fn flush(&self) {
+        // No need to flush
+    }
+}
+
+fn to_native_level(level: Level, promote_debug: bool) -> u32 {
+    match level {
+        Level::Error => LOG_ERROR,
+        Level::Warn => LOG_WARNING,
+        Level::Info => LOG_INFO,
+        _ => {
+            if promote_debug {
+                // Debug logs are only enabled in debug builds of OBS, make them accessible as info if needed
+                LOG_INFO
+            } else {
+                LOG_DEBUG
+            }
+        }
+    }
+}


### PR DESCRIPTION
This allows us to have a unified interface and possibly receive logs from other libraries (such as `hyper`).