### PR TITLE
Better property handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,4 @@ obs-sys = { path = "./obs-sys", version = "0.2.0" }
 serde_json = "1.0.48"
 paste = "0.1.7"
 log = "0.4.11"
-
-[dependencies.num]
-version = "0.3"
-default-features = false
+num-traits = "0.2.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,7 @@ obs-sys = { path = "./obs-sys", version = "0.2.0" }
 serde_json = "1.0.48"
 paste = "0.1.7"
 log = "0.4.11"
+
+[dependencies.num]
+version = "0.3"
+default-features = false

--- a/plugins/scroll-focus-filter/src/lib.rs
+++ b/plugins/scroll-focus-filter/src/lib.rs
@@ -79,61 +79,44 @@ impl GetNameSource<Data> for ScrollFocusFilter {
 impl GetPropertiesSource<Data> for ScrollFocusFilter {
     fn get_properties(_data: &mut Option<Data>, properties: &mut Properties) {
         properties
-            .add_float(
+            .add(
                 obs_string!("zoom"),
                 obs_string!("Amount to zoom in window"),
-                1.,
-                5.,
-                0.001,
-                true,
+                NumberProp::new_float(0.001)
+                    .with_range((1.)..=5.)
+                    .with_slider(),
             )
-            .add_int(
+            .add(
                 obs_string!("screen_x"),
                 obs_string!("Offset relative to top left screen - x"),
-                0,
-                3840 * 3,
-                1,
-                false,
+                NumberProp::new_int().with_range(..=3840 * 3u32),
             )
-            .add_int(
+            .add(
                 obs_string!("screen_y"),
                 obs_string!("Offset relative to top left screen - y"),
-                0,
-                3840 * 3,
-                1,
-                false,
+                NumberProp::new_int().with_range(..=3840 * 3u32),
             )
-            .add_float(
+            .add(
                 obs_string!("padding"),
                 obs_string!("Padding around each window"),
-                0.,
-                0.5,
-                0.001,
-                true,
+                NumberProp::new_float(0.001)
+                    .with_range(..=0.5)
+                    .with_slider(),
             )
-            .add_int(
+            .add(
                 obs_string!("screen_width"),
                 obs_string!("Screen width"),
-                1,
-                3840 * 3,
-                1,
-                false,
+                NumberProp::new_int().with_range(..=3840 * 3u32),
             )
-            .add_int(
+            .add(
                 obs_string!("screen_height"),
                 obs_string!("Screen height"),
-                1,
-                3840 * 3,
-                1,
-                false,
+                NumberProp::new_int().with_range(..=3840 * 3u32),
             )
-            .add_float(
+            .add(
                 obs_string!("animation_time"),
                 obs_string!("Animation Time (s)"),
-                0.3,
-                10.,
-                0.001,
-                false,
+                NumberProp::new_float(0.001).with_range(0.3..=10.),
             );
     }
 }

--- a/plugins/scroll-focus-filter/src/lib.rs
+++ b/plugins/scroll-focus-filter/src/lib.rs
@@ -277,11 +277,11 @@ impl CreatableSource<Data> for ScrollFocusFilter {
 
             let sampler = GraphicsSamplerState::from(GraphicsSamplerInfo::default());
 
-            let screen_width = settings.get(obs_string!("screen_width")).unwrap_or(1920) as u32;
-            let screen_height = settings.get(obs_string!("screen_height")).unwrap_or(1080) as u32;
+            let screen_width = settings.get(obs_string!("screen_width")).unwrap_or(1920);
+            let screen_height = settings.get(obs_string!("screen_height")).unwrap_or(1080);
 
-            let screen_x = settings.get(obs_string!("screen_x")).unwrap_or(0) as u32;
-            let screen_y = settings.get(obs_string!("screen_y")).unwrap_or(0) as u32;
+            let screen_x = settings.get(obs_string!("screen_x")).unwrap_or(0);
+            let screen_y = settings.get(obs_string!("screen_y")).unwrap_or(0);
 
             let animation_time = settings.get(obs_string!("animation_time")).unwrap_or(0.3);
 
@@ -360,8 +360,8 @@ impl UpdateSource<Data> for ScrollFocusFilter {
                 data.target_zoom = 1. / zoom;
             }
 
-            if let Some(screen_width) = settings.get::<i64, _>(obs_string!("screen_width")) {
-                data.screen_width = screen_width as u32;
+            if let Some(screen_width) = settings.get(obs_string!("screen_width")) {
+                data.screen_width = screen_width;
             }
 
             if let Some(padding) = settings.get(obs_string!("padding")) {
@@ -372,14 +372,16 @@ impl UpdateSource<Data> for ScrollFocusFilter {
                 data.animation_time = animation_time;
             }
 
-            if let Some(screen_height) = settings.get::<i64, _>(obs_string!("screen_height")) {
-                data.screen_height = screen_height as u32;
+            if let Some(screen_height) = settings.get(obs_string!("screen_height")) {
+                data.screen_height = screen_height;
             }
-            if let Some(screen_x) = settings.get::<i64, _>(obs_string!("screen_x")) {
-                data.screen_x = screen_x as u32;
+
+            if let Some(screen_x) = settings.get(obs_string!("screen_x")) {
+                data.screen_x = screen_x;
             }
-            if let Some(screen_y) = settings.get::<i64, _>(obs_string!("screen_y")) {
-                data.screen_y = screen_y as u32;
+            
+            if let Some(screen_y) = settings.get(obs_string!("screen_y")) {
+                data.screen_y = screen_y;
             }
         }
     }

--- a/plugins/scroll-focus-filter/src/lib.rs
+++ b/plugins/scroll-focus-filter/src/lib.rs
@@ -83,18 +83,18 @@ impl GetPropertiesSource<Data> for ScrollFocusFilter {
                 obs_string!("zoom"),
                 obs_string!("Amount to zoom in window"),
                 NumberProp::new_float(0.001)
-                    .with_range((1.)..=5.)
+                    .with_range(1.0..=5.0)
                     .with_slider(),
             )
             .add(
                 obs_string!("screen_x"),
                 obs_string!("Offset relative to top left screen - x"),
-                NumberProp::new_int().with_range(..=3840 * 3u32),
+                NumberProp::new_int().with_range(1u32..=3840 * 3),
             )
             .add(
                 obs_string!("screen_y"),
                 obs_string!("Offset relative to top left screen - y"),
-                NumberProp::new_int().with_range(..=3840 * 3u32),
+                NumberProp::new_int().with_range(1u32..=3840 * 3),
             )
             .add(
                 obs_string!("padding"),
@@ -106,12 +106,12 @@ impl GetPropertiesSource<Data> for ScrollFocusFilter {
             .add(
                 obs_string!("screen_width"),
                 obs_string!("Screen width"),
-                NumberProp::new_int().with_range(..=3840 * 3u32),
+                NumberProp::new_int().with_range(1u32..=3840 * 3),
             )
             .add(
                 obs_string!("screen_height"),
                 obs_string!("Screen height"),
-                NumberProp::new_int().with_range(..=3840 * 3u32),
+                NumberProp::new_int().with_range(1u32..=3840 * 3),
             )
             .add(
                 obs_string!("animation_time"),
@@ -379,7 +379,7 @@ impl UpdateSource<Data> for ScrollFocusFilter {
             if let Some(screen_x) = settings.get(obs_string!("screen_x")) {
                 data.screen_x = screen_x;
             }
-            
+
             if let Some(screen_y) = settings.get(obs_string!("screen_y")) {
                 data.screen_y = screen_y;
             }

--- a/src/data.rs
+++ b/src/data.rs
@@ -157,7 +157,7 @@ impl DataObj<'_> {
             Self::from_raw(raw)
         }
     }
-
+    /// Loads data into a object from a JSON string.
     pub fn from_json(json_str: impl Into<ObsString>) -> Option<Self> {
         let json_str = json_str.into();
         unsafe {
@@ -169,7 +169,8 @@ impl DataObj<'_> {
             }
         }
     }
-
+    /// Loads data into a object from a JSON file.
+    /// * `backup_ext`: optional backup file path in case the original file is bad.
     pub fn from_json_file(
         json_file: impl Into<ObsString>,
         backup_ext: impl Into<Option<ObsString>>,
@@ -189,7 +190,7 @@ impl DataObj<'_> {
             }
         }
     }
-
+    /// Fetches a property from this object. Numbers are implicitly casted.
     pub fn get<T: FromDataItem, N: Into<ObsString>>(&self, name: N) -> Option<T> {
         let name = name.into();
         let mut item_ptr = unsafe { obs_data_item_byname(self.raw, name.as_ptr()) };
@@ -210,7 +211,7 @@ impl DataObj<'_> {
             None
         }
     }
-
+    /// Creates a JSON representation of this object.
     pub fn get_json(&self) -> Option<String> {
         unsafe {
             let ptr = obs_data_get_json(self.raw);
@@ -222,11 +223,7 @@ impl DataObj<'_> {
             }
         }
     }
-
-    pub fn as_raw(&self) -> *mut obs_data_t {
-        self.raw
-    }
-
+    /// Clears all values.
     pub fn clear(&mut self) {
         unsafe {
             obs_data_clear(self.raw);

--- a/src/data.rs
+++ b/src/data.rs
@@ -66,14 +66,22 @@ impl FromDataItem for Cow<'_, str> {
     }
 }
 
-impl FromDataItem for i64 {
-    fn typ() -> DataType {
-        DataType::Int
-    }
-    unsafe fn from_item_unchecked(item: *mut obs_data_item_t) -> Self {
-        obs_data_item_get_int(item)
-    }
+macro_rules! impl_get_int {
+    ($($t:ty)*) => {
+        $(
+            impl FromDataItem for $t {
+                fn typ() -> DataType {
+                    DataType::Int
+                }
+                unsafe fn from_item_unchecked(item: *mut obs_data_item_t) -> Self {
+                    obs_data_item_get_int(item) as $t
+                }
+            }
+        )*
+    };
 }
+
+impl_get_int!(i64 u64 i32 u32 i16 u16 i8 u8 isize usize);
 
 impl FromDataItem for f64 {
     fn typ() -> DataType {
@@ -81,6 +89,15 @@ impl FromDataItem for f64 {
     }
     unsafe fn from_item_unchecked(item: *mut obs_data_item_t) -> Self {
         obs_data_item_get_double(item)
+    }
+}
+
+impl FromDataItem for f32 {
+    fn typ() -> DataType {
+        DataType::Double
+    }
+    unsafe fn from_item_unchecked(item: *mut obs_data_item_t) -> Self {
+        obs_data_item_get_double(item) as f32
     }
 }
 
@@ -148,7 +165,7 @@ impl DataObj<'_> {
             if raw.is_null() {
                 None
             } else {
-                Some( Self::from_raw(raw))
+                Some(Self::from_raw(raw))
             }
         }
     }

--- a/src/data.rs
+++ b/src/data.rs
@@ -193,7 +193,7 @@ impl DataObj<'_> {
     /// Fetches a property from this object. Numbers are implicitly casted.
     pub fn get<T: FromDataItem, N: Into<ObsString>>(&self, name: N) -> Option<T> {
         let name = name.into();
-        let mut item_ptr = unsafe { obs_data_item_byname(self.raw, name.as_ptr()) };
+        let mut item_ptr = unsafe { obs_data_item_byname(self.as_ptr() as *mut _, name.as_ptr()) };
         if item_ptr.is_null() {
             return None;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,10 +125,10 @@ pub mod module;
 pub mod source;
 /// String macros
 pub mod string;
-
+/// `obs_data_t` handling
 pub mod data;
-
-pub mod wrapper;
+/// FFI pointer wrapper
+mod wrapper;
 
 mod native_enum;
 
@@ -139,6 +139,7 @@ pub mod prelude {
     pub use crate::source::context::*;
     pub use crate::string::*;
 }
+
 #[derive(Debug)]
 pub struct Error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,6 +128,8 @@ pub mod string;
 
 pub mod data;
 
+pub mod wrapper;
+
 mod native_enum;
 
 /// Re-exports of a bunch of popular tools

--- a/src/source/context.rs
+++ b/src/source/context.rs
@@ -33,14 +33,14 @@ pub struct CreatableSourceContext<'a, D> {
         ObsString,
         Box<dyn FnMut(&mut Hotkey, &mut Option<D>)>,
     )>,
-    pub settings: DataObj<'a>,
+    pub settings: &'a mut DataObj<'a>,
     pub global: &'a mut GlobalContext,
 }
 
 impl<'a, D> CreatableSourceContext<'a, D> {
     pub(crate) unsafe fn from_raw(
         source: *mut obs_source_t,
-        settings: DataObj<'a>,
+        settings: &'a mut DataObj<'a>,
         global: &'a mut GlobalContext,
     ) -> Self {
         Self {

--- a/src/source/context.rs
+++ b/src/source/context.rs
@@ -33,14 +33,14 @@ pub struct CreatableSourceContext<'a, D> {
         ObsString,
         Box<dyn FnMut(&mut Hotkey, &mut Option<D>)>,
     )>,
-    pub settings: &'a mut DataObj<'a>,
+    pub settings: DataObj<'a>,
     pub global: &'a mut GlobalContext,
 }
 
 impl<'a, D> CreatableSourceContext<'a, D> {
     pub(crate) unsafe fn from_raw(
         source: *mut obs_source_t,
-        settings: &'a mut DataObj<'a>,
+        settings: DataObj<'a>,
         global: &'a mut GlobalContext,
     ) -> Self {
         Self {

--- a/src/source/context.rs
+++ b/src/source/context.rs
@@ -27,7 +27,7 @@ impl Default for GlobalContext {
 }
 
 pub struct CreatableSourceContext<'a, D> {
-    source: *mut obs_source_t,
+    _source: *mut obs_source_t,
     pub(crate) hotkey_callbacks: Vec<(
         ObsString,
         ObsString,
@@ -44,7 +44,7 @@ impl<'a, D> CreatableSourceContext<'a, D> {
         global: &'a mut GlobalContext,
     ) -> Self {
         Self {
-            source,
+            _source: source,
             hotkey_callbacks: Default::default(),
             settings,
             global,

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -36,7 +36,7 @@ use super::{
     },
     string::ObsString,
 };
-use crate::data::DataObj;
+use crate::{data::DataObj, wrapper::PtrWrapper};
 
 use std::{
     ffi::{CStr, CString},
@@ -288,9 +288,9 @@ impl SourceContext {
     }
 
     /// Update the source settings based on a settings context.
-    pub fn update_source_settings(&mut self, settings: &DataObj) {
+    pub fn update_source_settings(&mut self, settings: &mut DataObj) {
         unsafe {
-            obs_source_update(self.source, settings.as_raw());
+            obs_source_update(self.source, settings.as_ptr_mut());
         }
     }
 }

--- a/src/source/properties.rs
+++ b/src/source/properties.rs
@@ -55,6 +55,8 @@ native_enum!(EditableListType, obs_editable_list_type {
     FilesAndUrls => OBS_EDITABLE_LIST_TYPE_FILES_AND_URLS
 });
 
+/// Wrapper around [`obs_properties_t`], which is used by
+/// OBS to generate a user-friendly configuration UI.
 pub struct Properties {
     pointer: *mut obs_properties_t,
 }
@@ -121,6 +123,8 @@ impl Drop for Properties {
     }
 }
 
+/// Wrapper around [`obs_property_t`], which is a list of possible values for a
+/// property.
 pub struct ListProp<'props, T> {
     raw: *mut obs_property_t,
     _props: PhantomData<&'props mut Properties>,
@@ -229,7 +233,9 @@ enum NumberType {
     Integer,
     Float,
 }
-
+/// ## Panics
+/// This type of property may cause panic when being added to the properties
+/// if the provided `min`, `max` or `step` exceeds [`c_int`].
 pub struct NumberProp<T> {
     min: T,
     max: T,
@@ -252,7 +258,7 @@ impl<T: PrimInt> NumberProp<T> {
 }
 
 impl<T: Float> NumberProp<T> {
-    /// Creates a new float property.
+    /// Creates a new float property with a certain step.
     pub fn new_float(step: T) -> Self {
         Self {
             min: T::min_value(),
@@ -296,7 +302,7 @@ impl<T: Num + Bounded + Copy> NumberProp<T> {
 }
 
 pub trait ObsProp {
-    /// Callback to add this property to a `obs_properties_t`.
+    /// Callback to add this property to a [`obs_properties_t`].
     unsafe fn add_to_props(self, p: *mut obs_properties_t, name: ObsString, description: ObsString);
 }
 

--- a/src/source/properties.rs
+++ b/src/source/properties.rs
@@ -1,6 +1,6 @@
 use super::ObsString;
 use crate::{native_enum, wrapper::PtrWrapper};
-use num::{one, traits::Float, Bounded, Num, NumCast, PrimInt, ToPrimitive};
+use num_traits::{Bounded, Float, Num, NumCast, PrimInt, ToPrimitive, one};
 use obs_sys::{
     obs_combo_format, obs_combo_format_OBS_COMBO_FORMAT_FLOAT,
     obs_combo_format_OBS_COMBO_FORMAT_INT, obs_combo_format_OBS_COMBO_FORMAT_INVALID,

--- a/src/source/properties.rs
+++ b/src/source/properties.rs
@@ -98,7 +98,7 @@ impl Properties {
         name: ObsString,
         description: ObsString,
         editable: bool,
-    ) -> &mut ListProp<T> {
+    ) -> ListProp<T> {
         unsafe {
             let raw = obs_properties_add_list(
                 self.pointer,
@@ -112,7 +112,7 @@ impl Properties {
                 .into(),
                 T::format().into(),
             );
-            ListProp::from_ptr_mut(raw)
+            ListProp::from_raw(raw)
         }
     }
 }

--- a/src/source/properties.rs
+++ b/src/source/properties.rs
@@ -239,6 +239,7 @@ pub struct NumberProp<T> {
 }
 
 impl<T: PrimInt> NumberProp<T> {
+    /// Creates a new integer property with step set to 1.
     pub fn new_int() -> Self {
         Self {
             min: T::min_value(),
@@ -251,6 +252,7 @@ impl<T: PrimInt> NumberProp<T> {
 }
 
 impl<T: Float> NumberProp<T> {
+    /// Creates a new float property.
     pub fn new_float(step: T) -> Self {
         Self {
             min: T::min_value(),
@@ -263,11 +265,13 @@ impl<T: Float> NumberProp<T> {
 }
 
 impl<T: Num + Bounded + Copy> NumberProp<T> {
-    pub fn with_min(mut self, min: T) -> Self {
-        self.min = min;
+    /// Sets the step of the property.
+    pub fn with_step(mut self, step: T) -> Self {
+        self.step = step;
         self
     }
-
+    /// Sets the range of the property, inclusion and exclustion are calucated
+    /// based on the **current step**.
     pub fn with_range<R: RangeBounds<T>>(mut self, range: R) -> Self {
         use std::ops::Bound::*;
         self.min = match range.start_bound() {
@@ -284,7 +288,7 @@ impl<T: Num + Bounded + Copy> NumberProp<T> {
 
         self
     }
-
+    /// Sets this property as a slider.
     pub fn with_slider(mut self) -> Self {
         self.slider = true;
         self
@@ -292,6 +296,7 @@ impl<T: Num + Bounded + Copy> NumberProp<T> {
 }
 
 pub trait ObsProp {
+    /// Callback to add this property to a `obs_properties_t`.
     unsafe fn add_to_props(self, p: *mut obs_properties_t, name: ObsString, description: ObsString);
 }
 
@@ -307,6 +312,7 @@ impl<T: ToPrimitive> ObsProp for NumberProp<T> {
                 let min: c_int = NumCast::from(self.min).unwrap();
                 let max: c_int = NumCast::from(self.max).unwrap();
                 let step: c_int = NumCast::from(self.step).unwrap();
+
                 if self.slider {
                     obs_properties_add_int_slider(
                         p,
@@ -324,6 +330,7 @@ impl<T: ToPrimitive> ObsProp for NumberProp<T> {
                 let min: f64 = NumCast::from(self.min).unwrap();
                 let max: f64 = NumCast::from(self.max).unwrap();
                 let step: f64 = NumCast::from(self.step).unwrap();
+
                 if self.slider {
                     obs_properties_add_float_slider(
                         p,

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,4 +1,4 @@
-use std::ffi::CString;
+use std::{ffi::CString, ptr::null};
 
 #[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub enum ObsString {
@@ -26,6 +26,10 @@ impl ObsString {
             Self::Static(s) => (*s).as_ptr() as *const std::os::raw::c_char,
             Self::Dynamic(s) => s.as_ptr(),
         }
+    }
+
+    pub fn ptr_or_null(opt: &Option<Self>) -> *const std::os::raw::c_char {
+        opt.as_ref().map(|s| s.as_ptr()).unwrap_or(null())
     }
 }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,0 +1,40 @@
+use std::mem::forget;
+
+pub trait PtrWrapper: Sized {
+    type Pointer;
+    /// Wraps the pointer into a **owned** wrapper.
+    unsafe fn from_raw(raw: *mut Self::Pointer) -> Self;
+
+    /// Returns the inner pointer.
+    fn as_ptr(&self) -> *const Self::Pointer;
+
+    /// Wraps the pointer into a **borrowed** wrapper.
+    unsafe fn from_ptr_mut<'a>(raw: *mut Self::Pointer) -> &'a mut Self {
+        let mut s = Self::from_raw(raw);
+        let r = &mut s as *mut Self;
+        forget(s);
+        r.as_mut().unwrap()
+    }
+
+    /// Wraps the pointer into a **borrowed** wrapper.
+    unsafe fn from_ptr<'a>(raw: *const Self::Pointer) -> &'a Self {
+        let s = Self::from_raw(raw as *mut _);
+        let r = &s as *const Self;
+        forget(s);
+        r.as_ref().unwrap()
+    }
+
+    /// Consumes the wrapper and transfers ownershop to the pointer
+    ///
+    /// Do **NOT** drop the wrapper
+    fn into_raw(mut self) -> *mut Self::Pointer {
+        let raw = self.as_ptr_mut();
+        forget(self);
+        raw
+    }
+
+    /// Returns the inner pointer (mutable version).
+    fn as_ptr_mut(&mut self) -> *mut Self::Pointer {
+        self.as_ptr() as *mut _
+    }
+}

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -8,22 +8,6 @@ pub trait PtrWrapper: Sized {
     /// Returns the inner pointer.
     fn as_ptr(&self) -> *const Self::Pointer;
 
-    /// Wraps the pointer into a **borrowed** wrapper.
-    unsafe fn from_ptr_mut<'a>(raw: *mut Self::Pointer) -> &'a mut Self {
-        let mut s = Self::from_raw(raw);
-        let r = &mut s as *mut Self;
-        forget(s);
-        r.as_mut().unwrap()
-    }
-
-    /// Wraps the pointer into a **borrowed** wrapper.
-    unsafe fn from_ptr<'a>(raw: *const Self::Pointer) -> &'a Self {
-        let s = Self::from_raw(raw as *mut _);
-        let r = &s as *const Self;
-        forget(s);
-        r.as_ref().unwrap()
-    }
-
     /// Consumes the wrapper and transfers ownershop to the pointer
     ///
     /// This does **NOT** drop the wrapper internally.

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -26,7 +26,7 @@ pub trait PtrWrapper: Sized {
 
     /// Consumes the wrapper and transfers ownershop to the pointer
     ///
-    /// Do **NOT** drop the wrapper
+    /// This does **NOT** drop the wrapper internally.
     fn into_raw(mut self) -> *mut Self::Pointer {
         let raw = self.as_ptr_mut();
         forget(self);


### PR DESCRIPTION
What's in this PR:
* Use traits and builder pattern in property and data handling to reduce clutter
* Establish a general wrapper trait for pointers to avoid accidentally getting a use-after-free in OBS and get a consistent API when dealing with pointers.