### PR TITLE
Add repo link to crate manifests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Bennett Hardwick <me@bennetthardwick.com>"]
 edition = "2018"
 license = "GPL-2.0"
 description = "Safe wrapper of obs-sys"
+repository = "https://github.com/bennetthardwick/rust-obs-plugins"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/obs-sys/Cargo.toml
+++ b/obs-sys/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 links = "obs"
 description = "Bindgen of <obs/obs.h>"
 license = "GPL-2.0"
+repository = "https://github.com/bennetthardwick/rust-obs-plugins"
 
 [build-dependencies]
 bindgen = "0.53.1"


### PR DESCRIPTION
Finding this repo from docs.rs required clicking through to your profile, then finding your GitHub profile from another one of your crates. This should make it easier for future releases.