### PR TITLE
Bump Bindgen to 0.57

### DIFF
--- a/obs-sys/Cargo.toml
+++ b/obs-sys/Cargo.toml
@@ -9,7 +9,7 @@ license = "GPL-2.0"
 repository = "https://github.com/bennetthardwick/rust-obs-plugins"
 
 [build-dependencies]
-bindgen = "0.53.1"
+bindgen = "0.57"
 
 [target.'cfg(windows)'.build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
Increase the Bindgen version so that it no longer conflicts with
the version used in the pipewire-rs crate.