### PR TITLE
Turn on std feature for log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,5 +20,5 @@ members = [
 obs-sys = { path = "./obs-sys", version = "0.2.0" }
 serde_json = "1.0.48"
 paste = "0.1.7"
-log = "0.4.11"
+log = {version = "0.4.11", features = ["std"]}
 num-traits = "0.2.14"


### PR DESCRIPTION
In [`src/log.rs`](https://github.com/bennetthardwick/rust-obs-plugins/blob/ff72795078ce48c9075334cc2b6f4d0256b8a2de/src/log.rs#L49) the [`log::set_boxed_logger`](https://docs.rs/log/0.4.14/log/fn.set_boxed_logger.html) function is called, which requires the optional `std` feature for `log`. The crate won't build without it.