### PR TITLE
Icons / Interactable Sources / Defaults

### DIFF
--- a/obs-sys/build_win.rs
+++ b/obs-sys/build_win.rs
@@ -36,9 +36,9 @@ pub fn find_windows_obs_lib() {
         return;
     }
     // MSVC doesn't link against normal libraries,
-    // and Windows doesn't have a standard mechanism for locating build-time dependencies.
-    // Try to locate an OBS installation using the registry and then generate a .lib file
-    // containing all symbols exported by libobs.
+    // and Windows doesn't have a standard mechanism for locating build-time
+    // dependencies. Try to locate an OBS installation using the registry and
+    // then generate a .lib file containing all symbols exported by libobs.
     let target = env::var("TARGET").unwrap();
     if let Some((dll_path, arch)) = RegKey::predef(HKEY_LOCAL_MACHINE)
         .open_subkey_with_flags("SOFTWARE\\OBS Studio", KEY_READ | KEY_WOW64_32KEY)

--- a/plugins/scroll-focus-filter/src/lib.rs
+++ b/plugins/scroll-focus-filter/src/lib.rs
@@ -2,7 +2,9 @@ mod server;
 
 use server::{Server, WindowSnapshot};
 
-use obs_wrapper::{graphics::*, obs_register_module, obs_string, prelude::*, source::*, properties::*};
+use obs_wrapper::{
+    graphics::*, obs_register_module, obs_string, prelude::*, properties::*, source::*,
+};
 
 use crossbeam_channel::{unbounded, Receiver, Sender};
 
@@ -295,11 +297,7 @@ impl VideoTickSource for ScrollFocusFilter {
 }
 
 impl VideoRenderSource for ScrollFocusFilter {
-    fn video_render(
-        &mut self,
-        _context: &mut GlobalContext,
-        render: &mut VideoRenderContext,
-    ) {
+    fn video_render(&mut self, _context: &mut GlobalContext, render: &mut VideoRenderContext) {
         let data = self;
         let effect = &mut data.effect;
         let source = &mut data.source;

--- a/src/data.rs
+++ b/src/data.rs
@@ -170,7 +170,8 @@ impl DataObj<'_> {
         }
     }
     /// Loads data into a object from a JSON file.
-    /// * `backup_ext`: optional backup file path in case the original file is bad.
+    /// * `backup_ext`: optional backup file path in case the original file is
+    ///   bad.
     pub fn from_json_file(
         json_file: impl Into<ObsString>,
         backup_ext: impl Into<Option<ObsString>>,

--- a/src/data.rs
+++ b/src/data.rs
@@ -53,6 +53,9 @@ impl DataType {
 
 pub trait FromDataItem {
     fn typ() -> DataType;
+    /// # Safety
+    ///
+    /// Pointer must be valid.
     unsafe fn from_item_unchecked(item: *mut obs_data_item_t) -> Self;
 }
 
@@ -146,6 +149,12 @@ impl PtrWrapper for DataObj<'_> {
 
     fn as_ptr(&self) -> *const Self::Pointer {
         self.raw
+    }
+}
+
+impl Default for DataObj<'_> {
+    fn default() -> Self {
+        DataObj::new()
     }
 }
 
@@ -270,6 +279,10 @@ impl PtrWrapper for DataArray<'_> {
 impl DataArray<'_> {
     pub fn len(&self) -> usize {
         unsafe { obs_data_array_count(self.raw) as usize }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
     }
 
     pub fn get(&self, index: usize) -> Option<DataObj> {

--- a/src/data.rs
+++ b/src/data.rs
@@ -1,5 +1,9 @@
 #![allow(non_upper_case_globals)]
-use std::{borrow::Cow, ffi::CStr, marker::PhantomData};
+use std::{
+    borrow::Cow,
+    ffi::{CStr, CString},
+    marker::PhantomData,
+};
 
 use obs_sys::{
     obs_data_array_count, obs_data_array_item, obs_data_array_release, obs_data_array_t,
@@ -9,9 +13,11 @@ use obs_sys::{
     obs_data_item_get_int, obs_data_item_get_obj, obs_data_item_get_string, obs_data_item_gettype,
     obs_data_item_numtype, obs_data_item_release, obs_data_item_t, obs_data_number_type,
     obs_data_number_type_OBS_DATA_NUM_DOUBLE, obs_data_number_type_OBS_DATA_NUM_INT,
-    obs_data_release, obs_data_t, obs_data_type, obs_data_type_OBS_DATA_ARRAY,
-    obs_data_type_OBS_DATA_BOOLEAN, obs_data_type_OBS_DATA_NUMBER, obs_data_type_OBS_DATA_OBJECT,
-    obs_data_type_OBS_DATA_STRING, size_t,
+    obs_data_release, obs_data_set_default_bool, obs_data_set_default_double,
+    obs_data_set_default_int, obs_data_set_default_obj, obs_data_set_default_string, obs_data_t,
+    obs_data_type, obs_data_type_OBS_DATA_ARRAY, obs_data_type_OBS_DATA_BOOLEAN,
+    obs_data_type_OBS_DATA_NUMBER, obs_data_type_OBS_DATA_OBJECT, obs_data_type_OBS_DATA_STRING,
+    size_t,
 };
 
 use crate::{string::ObsString, wrapper::PtrWrapper};
@@ -57,6 +63,11 @@ pub trait FromDataItem {
     ///
     /// Pointer must be valid.
     unsafe fn from_item_unchecked(item: *mut obs_data_item_t) -> Self;
+
+    /// # Safety
+    ///
+    /// Pointer must be valid.
+    unsafe fn set_default_unchecked(obj: *mut obs_data_t, name: ObsString, val: Self);
 }
 
 impl FromDataItem for Cow<'_, str> {
@@ -66,6 +77,10 @@ impl FromDataItem for Cow<'_, str> {
     unsafe fn from_item_unchecked(item: *mut obs_data_item_t) -> Self {
         let ptr = obs_data_item_get_string(item);
         CStr::from_ptr(ptr).to_string_lossy()
+    }
+    unsafe fn set_default_unchecked(obj: *mut obs_data_t, name: ObsString, val: Self) {
+        let s = CString::new(val.as_ref()).unwrap();
+        obs_data_set_default_string(obj, name.as_ptr(), s.as_ptr());
     }
 }
 
@@ -78,6 +93,9 @@ macro_rules! impl_get_int {
                 }
                 unsafe fn from_item_unchecked(item: *mut obs_data_item_t) -> Self {
                     obs_data_item_get_int(item) as $t
+                }
+                unsafe fn set_default_unchecked(obj: *mut obs_data_t, name: ObsString, val: Self) {
+                    obs_data_set_default_int(obj, name.as_ptr(), val as i64)
                 }
             }
         )*
@@ -93,6 +111,9 @@ impl FromDataItem for f64 {
     unsafe fn from_item_unchecked(item: *mut obs_data_item_t) -> Self {
         obs_data_item_get_double(item)
     }
+    unsafe fn set_default_unchecked(obj: *mut obs_data_t, name: ObsString, val: Self) {
+        obs_data_set_default_double(obj, name.as_ptr(), val)
+    }
 }
 
 impl FromDataItem for f32 {
@@ -101,6 +122,9 @@ impl FromDataItem for f32 {
     }
     unsafe fn from_item_unchecked(item: *mut obs_data_item_t) -> Self {
         obs_data_item_get_double(item) as f32
+    }
+    unsafe fn set_default_unchecked(obj: *mut obs_data_t, name: ObsString, val: Self) {
+        obs_data_set_default_double(obj, name.as_ptr(), val as f64)
     }
 }
 
@@ -111,6 +135,9 @@ impl FromDataItem for bool {
     unsafe fn from_item_unchecked(item: *mut obs_data_item_t) -> Self {
         obs_data_item_get_bool(item)
     }
+    unsafe fn set_default_unchecked(obj: *mut obs_data_t, name: ObsString, val: Self) {
+        obs_data_set_default_bool(obj, name.as_ptr(), val)
+    }
 }
 
 impl FromDataItem for DataObj<'_> {
@@ -120,6 +147,9 @@ impl FromDataItem for DataObj<'_> {
     unsafe fn from_item_unchecked(item: *mut obs_data_item_t) -> Self {
         Self::from_raw(obs_data_item_get_obj(item))
     }
+    unsafe fn set_default_unchecked(obj: *mut obs_data_t, name: ObsString, mut val: Self) {
+        obs_data_set_default_obj(obj, name.as_ptr(), val.as_ptr_mut())
+    }
 }
 
 impl FromDataItem for DataArray<'_> {
@@ -128,6 +158,9 @@ impl FromDataItem for DataArray<'_> {
     }
     unsafe fn from_item_unchecked(item: *mut obs_data_item_t) -> Self {
         Self::from_raw(obs_data_item_get_array(item))
+    }
+    unsafe fn set_default_unchecked(_obj: *mut obs_data_t, _name: ObsString, _val: Self) {
+        unimplemented!("obs_data_set_default_array function doesn't exist")
     }
 }
 
@@ -166,6 +199,7 @@ impl DataObj<'_> {
             Self::from_raw(raw)
         }
     }
+
     /// Loads data into a object from a JSON string.
     pub fn from_json(json_str: impl Into<ObsString>) -> Option<Self> {
         let json_str = json_str.into();
@@ -178,6 +212,7 @@ impl DataObj<'_> {
             }
         }
     }
+
     /// Loads data into a object from a JSON file.
     /// * `backup_ext`: optional backup file path in case the original file is
     ///   bad.
@@ -200,6 +235,7 @@ impl DataObj<'_> {
             }
         }
     }
+
     /// Fetches a property from this object. Numbers are implicitly casted.
     pub fn get<T: FromDataItem, N: Into<ObsString>>(&self, name: N) -> Option<T> {
         let name = name.into();
@@ -221,6 +257,21 @@ impl DataObj<'_> {
             None
         }
     }
+
+    /// Sets a default value for the key.
+    ///
+    /// Notes
+    /// -----
+    /// Setting a default value for a [`DataArray`] is current a no-op because
+    /// of a API problem of OBS.
+    pub fn set_default<N: Into<ObsString>, T: FromDataItem, V: Into<T>>(
+        &mut self,
+        name: N,
+        value: V,
+    ) {
+        unsafe { T::set_default_unchecked(self.as_ptr_mut(), name.into(), value.into()) }
+    }
+
     /// Creates a JSON representation of this object.
     pub fn get_json(&self) -> Option<String> {
         unsafe {
@@ -233,6 +284,7 @@ impl DataObj<'_> {
             }
         }
     }
+
     /// Clears all values.
     pub fn clear(&mut self) {
         unsafe {

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -44,7 +44,8 @@ use std::{os::raw::c_int, slice};
 use super::string::ObsString;
 
 /// Guard to guarantee that we exit graphics context properly.
-/// This does not prevent one from calling APIs that are not supposed to be called outside of the context.
+/// This does not prevent one from calling APIs that are not supposed to be
+/// called outside of the context.
 struct GraphicsGuard;
 
 impl GraphicsGuard {
@@ -183,8 +184,8 @@ pub struct GraphicsEffectParam {
 
 impl GraphicsEffectParam {
     /// # Safety
-    /// Creates a GraphicsEffectParam from a mutable reference. This data could be modified
-    /// somewhere else so this is UB.
+    /// Creates a GraphicsEffectParam from a mutable reference. This data could
+    /// be modified somewhere else so this is UB.
     pub unsafe fn from_raw(raw: *mut gs_eparam_t) -> Self {
         let mut info = gs_effect_param_info::default();
         gs_effect_get_param_info(raw, &mut info);
@@ -382,8 +383,8 @@ pub struct GraphicsEffectContext {}
 
 impl GraphicsEffectContext {
     /// # Safety
-    /// GraphicsEffectContext has methods that should only be used in certain situations.
-    /// Constructing it at the wrong time could cause UB.
+    /// GraphicsEffectContext has methods that should only be used in certain
+    /// situations. Constructing it at the wrong time could cause UB.
     pub unsafe fn new() -> Self {
         Self {}
     }

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -193,7 +193,7 @@ impl GraphicsEffectParam {
         let shader_type = ShaderParamType::from_raw(info.type_);
         let name = CString::from(CStr::from_ptr(info.name))
             .into_string()
-            .unwrap_or(String::from("{unknown-param-name}"));
+            .unwrap_or_else(|_| String::from("{unknown-param-name}"));
 
         Self {
             raw,
@@ -382,15 +382,12 @@ impl Drop for GraphicsSamplerState {
 pub struct GraphicsEffectContext {}
 
 impl GraphicsEffectContext {
-    /// # Safety
-    /// GraphicsEffectContext has methods that should only be used in certain
-    /// situations. Constructing it at the wrong time could cause UB.
-    pub unsafe fn new() -> Self {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
         Self {}
     }
 }
 
-impl GraphicsEffectContext {}
 #[derive(Debug, Eq, PartialEq, Clone, Copy)]
 pub enum GraphicsColorFormat {
     UNKNOWN,
@@ -604,7 +601,7 @@ macro_rules! vector_impls {
                 }
             )*
 
-            pub unsafe fn as_ptr(&mut self) -> *mut $name {
+            pub fn as_ptr(&mut self) -> *mut $name {
                 &mut self.raw
             }
         }
@@ -667,7 +664,7 @@ impl GraphicsTexture {
         MappedTexture::new(self)
     }
 
-    pub unsafe fn as_ptr(&self) -> *mut gs_texture_t {
+    pub fn as_ptr(&self) -> *mut gs_texture_t {
         self.raw
     }
 }

--- a/src/hotkey.rs
+++ b/src/hotkey.rs
@@ -1,5 +1,9 @@
 use obs_sys::{obs_hotkey_get_id, obs_hotkey_id, obs_hotkey_t};
 
+use crate::string::ObsString;
+
+pub type HotkeyCallbacks<T> = Vec<(ObsString, ObsString, Box<dyn FnMut(&mut Hotkey, &mut T)>)>;
+
 pub struct Hotkey {
     key: *mut obs_hotkey_t,
     pub pressed: bool,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,12 @@
 //! # Rust OBS Wrapper
 //!
-//! A safe wrapper around the OBS API, useful for creating OBS sources, filters and effects.
+//! A safe wrapper around the OBS API, useful for creating OBS sources, filters
+//! and effects.
 //!
 //! ## Usage
 //!
-//! In your `Cargo.toml` file add the following section, substituting `<module-name>` for the name of
-//! the module:
+//! In your `Cargo.toml` file add the following section, substituting
+//! `<module-name>` for the name of the module:
 //!
 //! ```toml
 //! [dependencies]
@@ -42,8 +43,8 @@
 //! // The source that will be shown inside OBS.
 //! struct TestSource;
 //!
-//! // Implement the Sourceable trait for TestSource, this is required for each source.
-//! // It allows you to specify the source ID and type.
+//! // Implement the Sourceable trait for TestSource, this is required for each
+//! source. // It allows you to specify the source ID and type.
 //! impl Sourceable for TestSource {
 //!     fn get_id() -> ObsString {
 //!         obs_string!("test_source")
@@ -53,8 +54,8 @@
 //!         SourceType::FILTER
 //!     }
 //!
-//!     fn create(create: &mut CreatableSourceContext<Self>, _source: SourceContext) -> Self {
-//!         Self
+//!     fn create(create: &mut CreatableSourceContext<Self>, _source:
+//! SourceContext) -> Self {         Self
 //!     }
 //! }
 //!
@@ -65,8 +66,8 @@
 //!     }
 //! }
 //!
-//! // Implement the Module trait for TestModule. This will handle the creation of the source and
-//! // has some methods for telling OBS a bit about itself.
+//! // Implement the Module trait for TestModule. This will handle the creation
+//! of the source and // has some methods for telling OBS a bit about itself.
 //! impl Module for TestModule {
 //!     fn new(context: ModuleContext) -> Self {
 //!         Self { context }
@@ -76,13 +77,13 @@
 //!         &self.context
 //!     }
 //!    
-//!     // Load the module - create all sources, returning true if all went well.
-//!     fn load(&mut self, load_context: &mut LoadContext) -> bool {
+//!     // Load the module - create all sources, returning true if all went
+//! well.     fn load(&mut self, load_context: &mut LoadContext) -> bool {
 //!         // Create the source
 //!         let source = load_context
 //!             .create_source_builder::<TestSource>()
-//!             // Since GetNameSource is implemented, this method needs to be called to
-//!             // enable it.
+//!             // Since GetNameSource is implemented, this method needs to be
+//! called to             // enable it.
 //!             .enable_get_name()
 //!             .build();
 //!    
@@ -110,8 +111,9 @@
 //! ### Installing
 //!
 //! 1. Run `cargo build --release`
-//! 2. Copy `/target/release/<module-name>.so` to your OBS plugins folder (`/usr/lib/obs-plugins/`)
-//! 3. The plugin should be available for use from inside OBS
+//! 2. Copy `/target/release/<module-name>.so` to your OBS plugins folder
+//! (`/usr/lib/obs-plugins/`) 3. The plugin should be available for use from
+//! inside OBS
 
 /// Raw bindings of OBS C API
 pub use obs_sys;
@@ -125,12 +127,12 @@ mod hotkey;
 pub mod log;
 /// Tools for creating modules
 pub mod module;
+/// Tools for creating outputs
+pub mod output;
 /// Tools for creating properties
 pub mod properties;
 /// Tools for creating sources
 pub mod source;
-/// Tools for creating outputs
-pub mod output;
 /// String macros
 pub mod string;
 /// FFI pointer wrapper

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -136,7 +136,7 @@ pub mod source;
 /// String macros
 pub mod string;
 /// FFI pointer wrapper
-mod wrapper;
+pub mod wrapper;
 
 mod native_enum;
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -9,9 +9,9 @@ use obs_sys::{_bindgen_ty_1, blog, LOG_DEBUG, LOG_ERROR, LOG_INFO, LOG_WARNING};
 /// only enabled in debug builds of OBS, this logger provides a option
 /// to promote lower-level logs as `info`.
 ///
-/// You can also use any other logger implementation, but we recommend this since
-/// OBS also writes everything in its logging system to a file, which can be viewed
-/// if there is a problem and OBS is not started from a console.
+/// You can also use any other logger implementation, but we recommend this
+/// since OBS also writes everything in its logging system to a file, which can
+/// be viewed if there is a problem and OBS is not started from a console.
 ///
 /// # Examples
 ///
@@ -42,8 +42,8 @@ impl Logger {
         Self::default()
     }
 
-    /// Initializes this logger, setting this as the global logger. This MUST be called to be effective.
-    /// This may fail if there is already a logger.
+    /// Initializes this logger, setting this as the global logger. This MUST be
+    /// called to be effective. This may fail if there is already a logger.
     pub fn init(self) -> Result<(), SetLoggerError> {
         log::set_max_level(self.max_level);
         log::set_boxed_logger(Box::new(self))?;
@@ -109,7 +109,8 @@ fn to_native_level(level: Level, promote_debug: bool) -> _bindgen_ty_1 {
         Level::Info => LOG_INFO,
         _ => {
             if promote_debug {
-                // Debug logs are only enabled in debug builds of OBS, make them accessible as info if needed
+                // Debug logs are only enabled in debug builds of OBS, make them accessible as
+                // info if needed
                 LOG_INFO
             } else {
                 LOG_DEBUG

--- a/src/module.rs
+++ b/src/module.rs
@@ -34,10 +34,9 @@ impl LoadContext {
     }
 
     pub fn register_source(&mut self, source: SourceInfo) {
-        let pointer = unsafe {
-            let pointer = source.into_raw();
+        let pointer = source.into_raw();
+        unsafe {
             obs_register_source_s(pointer, std::mem::size_of::<obs_source_info>() as size_t);
-            pointer
         };
         self.sources.push(pointer);
     }

--- a/src/module.rs
+++ b/src/module.rs
@@ -1,10 +1,8 @@
-use crate::source::{traits::Sourceable, SourceInfo, SourceInfoBuilder};
 use crate::output::{traits::Outputable, OutputInfo, OutputInfoBuilder};
+use crate::source::{traits::Sourceable, SourceInfo, SourceInfoBuilder};
 use crate::string::ObsString;
 use obs_sys::{
-    obs_module_t,
-    obs_register_source_s, obs_register_output_s,
-    obs_source_info, obs_output_info,
+    obs_module_t, obs_output_info, obs_register_output_s, obs_register_source_s, obs_source_info,
     size_t,
 };
 use std::marker::PhantomData;
@@ -17,8 +15,8 @@ pub struct LoadContext {
 
 impl LoadContext {
     /// # Safety
-    /// LoadContext can only be used at specific times. Creating it could cause UB if done at the
-    /// wrong time.
+    /// LoadContext can only be used at specific times. Creating it could cause
+    /// UB if done at the wrong time.
     pub unsafe fn new() -> LoadContext {
         LoadContext {
             __marker: PhantomData,
@@ -159,8 +157,8 @@ pub struct ModuleContext {
 
 impl ModuleContext {
     /// # Safety
-    /// Creates a ModuleContext from a pointer to the raw obs_module data which if modified could
-    /// cause UB.
+    /// Creates a ModuleContext from a pointer to the raw obs_module data which
+    /// if modified could cause UB.
     pub unsafe fn new(raw: *mut obs_module_t) -> Self {
         Self { raw }
     }

--- a/src/native_enum.rs
+++ b/src/native_enum.rs
@@ -31,6 +31,7 @@ macro_rules! native_enum {
                 $($rust),*
             }
 
+            #[allow(clippy::from_over_into)]
             impl Into<$native_name> for $name {
                 fn into(self) -> obs_text_type {
                     match self {
@@ -40,11 +41,11 @@ macro_rules! native_enum {
             }
 
             impl std::convert::TryFrom<$native_name> for $name {
-                type Error = crate::native_enum::NativeParsingError;
+                type Error = $crate::native_enum::NativeParsingError;
                 fn try_from(value: $native_name) -> Result<Self, Self::Error> {
                     match value {
                         $([<$native_name _ $native>] => Ok(Self::$rust)),*,
-                        _ => Err(crate::native_enum::NativeParsingError::new(stringify!($name), value as i64))
+                        _ => Err($crate::native_enum::NativeParsingError::new(stringify!($name), value as i64))
                     }
                 }
             }

--- a/src/output/context.rs
+++ b/src/output/context.rs
@@ -1,8 +1,9 @@
-use obs_sys::{obs_output_t, obs_output_create, obs_output_release, obs_output_get_ref};
+use obs_sys::{obs_output_create, obs_output_get_ref, obs_output_release, obs_output_t};
 
-use crate::{string::ObsString, hotkey::Hotkey, prelude::DataObj, wrapper::PtrWrapper};
+use crate::{hotkey::Hotkey, prelude::DataObj, string::ObsString, wrapper::PtrWrapper};
 
-/// Context wrapping an OBS output - video / audio elements which are displayed to the screen.
+/// Context wrapping an OBS output - video / audio elements which are displayed
+/// to the screen.
 ///
 /// See [OBS documentation](https://obsproject.com/docs/reference-outputs.html#c.obs_output_t)
 pub struct OutputContext {
@@ -12,7 +13,7 @@ pub struct OutputContext {
 impl OutputContext {
     pub fn from_raw(output: *mut obs_output_t) -> Self {
         Self {
-            inner: unsafe { obs_output_get_ref(output) }
+            inner: unsafe { obs_output_get_ref(output) },
         }
     }
 }
@@ -43,17 +44,16 @@ impl Drop for OutputContext {
 }
 
 pub struct CreatableOutputContext<'a, D> {
-    pub(crate) hotkey_callbacks: Vec<(
-        ObsString,
-        ObsString,
-        Box<dyn FnMut(&mut Hotkey, &mut D)>,
-    )>,
+    pub(crate) hotkey_callbacks: Vec<(ObsString, ObsString, Box<dyn FnMut(&mut Hotkey, &mut D)>)>,
     pub settings: DataObj<'a>,
 }
 
 impl<'a, D> CreatableOutputContext<'a, D> {
     pub fn from_raw(settings: DataObj<'a>) -> Self {
-        Self { hotkey_callbacks: vec![], settings }
+        Self {
+            hotkey_callbacks: vec![],
+            settings,
+        }
     }
 
     pub fn register_hotkey<F: FnMut(&mut Hotkey, &mut D) + 'static>(

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,16 +1,15 @@
-
 use paste::item;
 
 use std::marker::PhantomData;
 
-use obs_sys::{obs_output_info, OBS_OUTPUT_VIDEO, OBS_OUTPUT_AUDIO};
+use obs_sys::{obs_output_info, OBS_OUTPUT_AUDIO, OBS_OUTPUT_VIDEO};
 
-pub mod traits;
-mod ffi;
 pub mod context;
+mod ffi;
+pub mod traits;
 
-pub use traits::*;
 pub use context::*;
+pub use traits::*;
 
 pub struct OutputInfo {
     info: Box<obs_output_info>,
@@ -32,9 +31,9 @@ impl AsRef<obs_output_info> for OutputInfo {
 
 /// The OutputInfoBuilder that handles creating the [OutputInfo](https://obsproject.com/docs/reference-outputs.html#c.obs_output_info) object.
 ///
-/// For each trait that is implemented for the Output, it needs to be enabled using this builder.
-/// If an struct called `FocusFilter` implements `CreateOutput` and `GetNameOutput` it would need
-/// to enable those features.
+/// For each trait that is implemented for the Output, it needs to be enabled
+/// using this builder. If an struct called `FocusFilter` implements
+/// `CreateOutput` and `GetNameOutput` it would need to enable those features.
 ///
 /// ```rs
 /// let output = load_context
@@ -43,7 +42,6 @@ impl AsRef<obs_output_info> for OutputInfo {
 ///  .enable_create()
 ///  .build();
 /// ```
-///
 pub struct OutputInfoBuilder<D: Outputable> {
     __data: PhantomData<D>,
     info: obs_output_info,

--- a/src/output/traits.rs
+++ b/src/output/traits.rs
@@ -1,15 +1,17 @@
-use obs_sys::{video_data, audio_data, encoder_packet};
+use obs_sys::{audio_data, encoder_packet, video_data};
 
-use crate::{string::ObsString, prelude::DataObj, properties::Properties};
+use crate::{prelude::DataObj, properties::Properties, string::ObsString};
 
-use super::{OutputContext, CreatableOutputContext};
+use super::{CreatableOutputContext, OutputContext};
 
 pub trait Outputable: Sized {
     fn get_id() -> ObsString;
     fn create(context: &mut CreatableOutputContext<'_, Self>, output: OutputContext) -> Self;
 
-    fn start(&mut self) -> bool { true }
-    fn stop(&mut self, _ts: u64) { }
+    fn start(&mut self) -> bool {
+        true
+    }
+    fn stop(&mut self, _ts: u64) {}
 }
 
 pub trait GetNameOutput {

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -1,6 +1,6 @@
 #![allow(non_upper_case_globals)]
 
-use crate::{native_enum, wrapper::PtrWrapper, string::ObsString};
+use crate::{native_enum, string::ObsString, wrapper::PtrWrapper};
 use num_traits::{one, Bounded, Float, Num, NumCast, PrimInt, ToPrimitive};
 use obs_sys::{
     obs_combo_format, obs_combo_format_OBS_COMBO_FORMAT_FLOAT,
@@ -436,14 +436,13 @@ impl ObsProp for FontProp {
 /// "Example types 1 and 2 (*.ex1 *.ex2);;Example type 3 (*.ex3)"
 ///
 /// Arguments
-/// *  `props`: Properties object
-/// *  `name`: Settings name
-/// *  `description`: Description (display name) of the property
-/// *  `type`: Type of path (directory or file)
-/// *  `filter`: If type is a file path, then describes the file filter
-///              that the user can browse.  Items are separated via
-///              double semi-colens.  If multiple file types in a
-///              filter, separate with space.
+/// * `props`: Properties object
+/// * `name`: Settings name
+/// * `description`: Description (display name) of the property
+/// * `type`: Type of path (directory or file)
+/// * `filter`: If type is a file path, then describes the file filter that the
+///   user can browse.  Items are separated via double semi-colens.  If multiple
+///   file types in a filter, separate with space.
 pub struct PathProp {
     typ: PathType,
     filter: Option<ObsString>,

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -1,4 +1,5 @@
 #![allow(non_upper_case_globals)]
+#![allow(clippy::not_unsafe_ptr_arg_deref)]
 
 use crate::{native_enum, string::ObsString, wrapper::PtrWrapper};
 use num_traits::{one, Bounded, Float, Num, NumCast, PrimInt, ToPrimitive};
@@ -71,6 +72,12 @@ impl PtrWrapper for Properties {
 
     fn as_ptr(&self) -> *const Self::Pointer {
         self.pointer
+    }
+}
+
+impl Default for Properties {
+    fn default() -> Self {
+        Properties::new()
     }
 }
 
@@ -304,6 +311,10 @@ impl<T: Num + Bounded + Copy> NumberProp<T> {
 
 pub trait ObsProp {
     /// Callback to add this property to a [`obs_properties_t`].
+    ///
+    /// # Safety
+    ///
+    /// Must call with a valid pointer.
     unsafe fn add_to_props(self, p: *mut obs_properties_t, name: ObsString, description: ObsString);
 }
 

--- a/src/source/context.rs
+++ b/src/source/context.rs
@@ -1,5 +1,5 @@
 use super::audio::AudioRef;
-use crate::hotkey::Hotkey;
+use crate::hotkey::{Hotkey, HotkeyCallbacks};
 use crate::prelude::DataObj;
 use crate::string::ObsString;
 use obs_sys::obs_get_audio;
@@ -27,7 +27,7 @@ impl Default for GlobalContext {
 }
 
 pub struct CreatableSourceContext<'a, D> {
-    pub(crate) hotkey_callbacks: Vec<(ObsString, ObsString, Box<dyn FnMut(&mut Hotkey, &mut D)>)>,
+    pub(crate) hotkey_callbacks: HotkeyCallbacks<D>,
     pub settings: DataObj<'a>,
     pub global: &'a mut GlobalContext,
 }
@@ -52,7 +52,6 @@ impl<'a, D> CreatableSourceContext<'a, D> {
     }
 
     // Inherited from child contexts
-
     pub fn with_audio<T, F: FnOnce(&AudioRef) -> T>(&self, func: F) -> T {
         self.global.with_audio(func)
     }

--- a/src/source/context.rs
+++ b/src/source/context.rs
@@ -27,20 +27,13 @@ impl Default for GlobalContext {
 }
 
 pub struct CreatableSourceContext<'a, D> {
-    pub(crate) hotkey_callbacks: Vec<(
-        ObsString,
-        ObsString,
-        Box<dyn FnMut(&mut Hotkey, &mut D)>,
-    )>,
+    pub(crate) hotkey_callbacks: Vec<(ObsString, ObsString, Box<dyn FnMut(&mut Hotkey, &mut D)>)>,
     pub settings: DataObj<'a>,
     pub global: &'a mut GlobalContext,
 }
 
 impl<'a, D> CreatableSourceContext<'a, D> {
-    pub(crate) unsafe fn from_raw(
-        settings: DataObj<'a>,
-        global: &'a mut GlobalContext,
-    ) -> Self {
+    pub(crate) unsafe fn from_raw(settings: DataObj<'a>, global: &'a mut GlobalContext) -> Self {
         Self {
             hotkey_callbacks: Default::default(),
             settings,

--- a/src/source/ffi.rs
+++ b/src/source/ffi.rs
@@ -1,6 +1,6 @@
 use super::audio::AudioDataContext;
-use super::video::VideoDataContext;
 use super::context::{CreatableSourceContext, GlobalContext, VideoRenderContext};
+use super::video::VideoDataContext;
 use super::{traits::*, SourceContext};
 use super::{EnumActiveContext, EnumAllContext};
 use crate::{data::DataObj, hotkey::Hotkey, string::ObsString, wrapper::PtrWrapper};
@@ -13,7 +13,7 @@ use std::os::raw::c_char;
 use obs_sys::{
     gs_effect_t, obs_audio_data, obs_data_t, obs_hotkey_id, obs_hotkey_register_source,
     obs_hotkey_t, obs_media_state, obs_properties, obs_source_audio_mix, obs_source_enum_proc_t,
-    obs_source_t, size_t, obs_source_frame
+    obs_source_frame, obs_source_t, size_t,
 };
 
 struct DataWrapper<D> {
@@ -24,11 +24,7 @@ struct DataWrapper<D> {
 impl<D> DataWrapper<D> {
     pub(crate) unsafe fn register_callbacks(
         &mut self,
-        callbacks: Vec<(
-            ObsString,
-            ObsString,
-            Box<dyn FnMut(&mut Hotkey, &mut D)>,
-        )>,
+        callbacks: Vec<(ObsString, ObsString, Box<dyn FnMut(&mut Hotkey, &mut D)>)>,
         source: *mut obs_source_t,
         data: *mut c_void,
     ) {
@@ -68,9 +64,7 @@ macro_rules! impl_simple_fn {
     )*)
 }
 
-pub unsafe extern "C" fn get_name<D: GetNameSource>(
-    _type_data: *mut c_void,
-) -> *const c_char {
+pub unsafe extern "C" fn get_name<D: GetNameSource>(_type_data: *mut c_void) -> *const c_char {
     D::get_name().as_ptr()
 }
 
@@ -112,10 +106,7 @@ pub unsafe extern "C" fn destroy<D>(data: *mut c_void) {
     drop(wrapper);
 }
 
-pub unsafe extern "C" fn update<D: UpdateSource>(
-    data: *mut c_void,
-    settings: *mut obs_data_t,
-) {
+pub unsafe extern "C" fn update<D: UpdateSource>(data: *mut c_void, settings: *mut obs_data_t) {
     let mut global = GlobalContext::default();
     let data: &mut DataWrapper<D> = &mut *(data as *mut DataWrapper<D>);
     let mut settings = DataObj::from_raw(settings);

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -14,19 +14,29 @@ pub use media::*;
 pub use traits::*;
 
 use obs_sys::{
-    obs_filter_get_target, obs_source_active, obs_source_enabled, obs_source_get_base_height,
-    obs_source_get_base_width, obs_source_get_height, obs_source_get_id, obs_source_get_name,
-    obs_source_get_ref, obs_source_get_type, obs_source_get_width, obs_source_info,
-    obs_source_media_ended, obs_source_media_get_duration, obs_source_media_get_state,
-    obs_source_media_get_time, obs_source_media_next, obs_source_media_play_pause,
-    obs_source_media_previous, obs_source_media_restart, obs_source_media_set_time,
-    obs_source_media_started, obs_source_media_stop, obs_source_process_filter_begin,
-    obs_source_process_filter_end, obs_source_process_filter_tech_end, obs_source_release,
-    obs_source_set_enabled, obs_source_set_name, obs_source_showing, obs_source_skip_video_filter,
-    obs_source_t, obs_source_type, obs_source_type_OBS_SOURCE_TYPE_FILTER,
-    obs_source_type_OBS_SOURCE_TYPE_INPUT, obs_source_type_OBS_SOURCE_TYPE_SCENE,
-    obs_source_type_OBS_SOURCE_TYPE_TRANSITION, obs_source_update, OBS_SOURCE_AUDIO,
-    OBS_SOURCE_CONTROLLABLE_MEDIA, OBS_SOURCE_VIDEO,
+    obs_filter_get_target, obs_icon_type, obs_icon_type_OBS_ICON_TYPE_AUDIO_INPUT,
+    obs_icon_type_OBS_ICON_TYPE_AUDIO_OUTPUT, obs_icon_type_OBS_ICON_TYPE_BROWSER,
+    obs_icon_type_OBS_ICON_TYPE_CAMERA, obs_icon_type_OBS_ICON_TYPE_COLOR,
+    obs_icon_type_OBS_ICON_TYPE_CUSTOM, obs_icon_type_OBS_ICON_TYPE_DESKTOP_CAPTURE,
+    obs_icon_type_OBS_ICON_TYPE_GAME_CAPTURE, obs_icon_type_OBS_ICON_TYPE_IMAGE,
+    obs_icon_type_OBS_ICON_TYPE_MEDIA, obs_icon_type_OBS_ICON_TYPE_SLIDESHOW,
+    obs_icon_type_OBS_ICON_TYPE_TEXT, obs_icon_type_OBS_ICON_TYPE_UNKNOWN,
+    obs_icon_type_OBS_ICON_TYPE_WINDOW_CAPTURE, obs_mouse_button_type,
+    obs_mouse_button_type_MOUSE_LEFT, obs_mouse_button_type_MOUSE_MIDDLE,
+    obs_mouse_button_type_MOUSE_RIGHT, obs_source_active, obs_source_enabled,
+    obs_source_get_base_height, obs_source_get_base_width, obs_source_get_height,
+    obs_source_get_id, obs_source_get_name, obs_source_get_ref, obs_source_get_type,
+    obs_source_get_width, obs_source_info, obs_source_media_ended, obs_source_media_get_duration,
+    obs_source_media_get_state, obs_source_media_get_time, obs_source_media_next,
+    obs_source_media_play_pause, obs_source_media_previous, obs_source_media_restart,
+    obs_source_media_set_time, obs_source_media_started, obs_source_media_stop,
+    obs_source_process_filter_begin, obs_source_process_filter_end,
+    obs_source_process_filter_tech_end, obs_source_release, obs_source_set_enabled,
+    obs_source_set_name, obs_source_showing, obs_source_skip_video_filter, obs_source_t,
+    obs_source_type, obs_source_type_OBS_SOURCE_TYPE_FILTER, obs_source_type_OBS_SOURCE_TYPE_INPUT,
+    obs_source_type_OBS_SOURCE_TYPE_SCENE, obs_source_type_OBS_SOURCE_TYPE_TRANSITION,
+    obs_source_update, obs_text_type, OBS_SOURCE_AUDIO, OBS_SOURCE_CONTROLLABLE_MEDIA,
+    OBS_SOURCE_INTERACTION, OBS_SOURCE_VIDEO,
 };
 
 use super::{
@@ -35,12 +45,35 @@ use super::{
     },
     string::ObsString,
 };
-use crate::{data::DataObj, wrapper::PtrWrapper};
+use crate::{data::DataObj, native_enum, wrapper::PtrWrapper};
 
 use std::{
     ffi::{CStr, CString},
     marker::PhantomData,
 };
+
+native_enum!(MouseButton, obs_mouse_button_type {
+    Left => MOUSE_LEFT,
+    Middle => MOUSE_MIDDLE,
+    Right => MOUSE_RIGHT
+});
+
+native_enum!(Icon, obs_icon_type {
+    Unknown => OBS_ICON_TYPE_UNKNOWN,
+    Image => OBS_ICON_TYPE_IMAGE,
+    Color => OBS_ICON_TYPE_COLOR,
+    Slideshow => OBS_ICON_TYPE_SLIDESHOW,
+    AudioInput => OBS_ICON_TYPE_AUDIO_INPUT,
+    AudioOutput => OBS_ICON_TYPE_AUDIO_OUTPUT,
+    DesktopCapture => OBS_ICON_TYPE_DESKTOP_CAPTURE,
+    WindowCapture => OBS_ICON_TYPE_WINDOW_CAPTURE,
+    GameCapture => OBS_ICON_TYPE_GAME_CAPTURE,
+    Camera => OBS_ICON_TYPE_CAMERA,
+    Text => OBS_ICON_TYPE_TEXT,
+    Media => OBS_ICON_TYPE_MEDIA,
+    Browser => OBS_ICON_TYPE_BROWSER,
+    Custom => OBS_ICON_TYPE_CUSTOM
+});
 
 /// OBS source type
 ///
@@ -332,6 +365,10 @@ impl SourceInfo {
     pub fn into_raw(self) -> *mut obs_source_info {
         Box::into_raw(self.info)
     }
+
+    pub fn set_icon(&mut self, icon: Icon) {
+        self.info.icon_type = icon.into();
+    }
 }
 
 impl AsRef<obs_source_info> for SourceInfo {
@@ -392,9 +429,23 @@ impl<D: Sourceable> SourceInfoBuilder<D> {
             self.info.output_flags |= OBS_SOURCE_CONTROLLABLE_MEDIA;
         }
 
+        if self.info.mouse_click.is_some()
+            || self.info.mouse_move.is_some()
+            || self.info.mouse_wheel.is_some()
+            || self.info.focus.is_some()
+            || self.info.key_click.is_some()
+        {
+            self.info.output_flags |= OBS_SOURCE_INTERACTION;
+        }
+
         SourceInfo {
             info: Box::new(self.info),
         }
+    }
+
+    pub fn with_icon(mut self, icon: Icon) -> Self {
+        self.info.icon_type = icon.into();
+        self
     }
 }
 
@@ -438,4 +489,9 @@ impl_source_builder! {
     media_get_time => MediaGetTimeSource
     media_set_time => MediaSetTimeSource
     media_get_state => MediaGetStateSource
+    mouse_wheel => MouseWheelSource
+    mouse_click => MouseClickSource
+    mouse_move => MouseMoveSource
+    key_click => KeyClickSource
+    focus => FocusSource
 }

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -83,7 +83,10 @@ pub struct SourceContext {
 }
 
 impl SourceContext {
-    pub fn from_raw(source: *mut obs_source_t) -> Self {
+    /// # Safety
+    ///
+    /// Must call with a valid pointer.
+    pub unsafe fn from_raw(source: *mut obs_source_t) -> Self {
         Self {
             inner: unsafe { obs_source_get_ref(source) },
         }
@@ -92,7 +95,7 @@ impl SourceContext {
 
 impl Clone for SourceContext {
     fn clone(&self) -> Self {
-        Self::from_raw(self.inner)
+        unsafe { Self::from_raw(self.inner) }
     }
 }
 
@@ -279,6 +282,7 @@ impl SourceContext {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn process_filter_tech<F: FnOnce(&mut GraphicsEffectContext, &mut GraphicsEffect)>(
         &mut self,
         _render: &mut VideoRenderContext,
@@ -325,9 +329,7 @@ pub struct SourceInfo {
 }
 
 impl SourceInfo {
-    /// # Safety
-    /// Creates a raw pointer from a box and could cause UB is misused.
-    pub unsafe fn into_raw(self) -> *mut obs_source_info {
+    pub fn into_raw(self) -> *mut obs_source_info {
         Box::into_raw(self.info)
     }
 }
@@ -335,6 +337,12 @@ impl SourceInfo {
 impl AsRef<obs_source_info> for SourceInfo {
     fn as_ref(&self) -> &obs_source_info {
         self.info.as_ref()
+    }
+}
+
+impl AsMut<obs_source_info> for SourceInfo {
+    fn as_mut(&mut self) -> &mut obs_source_info {
+        self.info.as_mut()
     }
 }
 

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -16,16 +16,17 @@ pub use traits::*;
 use obs_sys::{
     obs_filter_get_target, obs_source_active, obs_source_enabled, obs_source_get_base_height,
     obs_source_get_base_width, obs_source_get_height, obs_source_get_id, obs_source_get_name,
-    obs_source_get_type, obs_source_get_width, obs_source_info, obs_source_media_ended,
-    obs_source_media_get_duration, obs_source_media_get_state, obs_source_media_get_time,
-    obs_source_media_next, obs_source_media_play_pause, obs_source_media_previous,
-    obs_source_media_restart, obs_source_media_set_time, obs_source_media_started,
-    obs_source_media_stop, obs_source_process_filter_begin, obs_source_process_filter_end,
-    obs_source_process_filter_tech_end, obs_source_set_enabled, obs_source_set_name,
-    obs_source_showing, obs_source_skip_video_filter, obs_source_t, obs_source_type,
-    obs_source_type_OBS_SOURCE_TYPE_FILTER, obs_source_type_OBS_SOURCE_TYPE_INPUT,
-    obs_source_type_OBS_SOURCE_TYPE_SCENE, obs_source_type_OBS_SOURCE_TYPE_TRANSITION,
-    obs_source_update, OBS_SOURCE_AUDIO, OBS_SOURCE_CONTROLLABLE_MEDIA, OBS_SOURCE_VIDEO, obs_source_get_ref, obs_source_release,
+    obs_source_get_ref, obs_source_get_type, obs_source_get_width, obs_source_info,
+    obs_source_media_ended, obs_source_media_get_duration, obs_source_media_get_state,
+    obs_source_media_get_time, obs_source_media_next, obs_source_media_play_pause,
+    obs_source_media_previous, obs_source_media_restart, obs_source_media_set_time,
+    obs_source_media_started, obs_source_media_stop, obs_source_process_filter_begin,
+    obs_source_process_filter_end, obs_source_process_filter_tech_end, obs_source_release,
+    obs_source_set_enabled, obs_source_set_name, obs_source_showing, obs_source_skip_video_filter,
+    obs_source_t, obs_source_type, obs_source_type_OBS_SOURCE_TYPE_FILTER,
+    obs_source_type_OBS_SOURCE_TYPE_INPUT, obs_source_type_OBS_SOURCE_TYPE_SCENE,
+    obs_source_type_OBS_SOURCE_TYPE_TRANSITION, obs_source_update, OBS_SOURCE_AUDIO,
+    OBS_SOURCE_CONTROLLABLE_MEDIA, OBS_SOURCE_VIDEO,
 };
 
 use super::{
@@ -73,7 +74,8 @@ impl SourceType {
     }
 }
 
-/// Context wrapping an OBS source - video / audio elements which are displayed to the screen.
+/// Context wrapping an OBS source - video / audio elements which are displayed
+/// to the screen.
 ///
 /// See [OBS documentation](https://obsproject.com/docs/reference-sources.html#c.obs_source_t)
 pub struct SourceContext {
@@ -83,7 +85,7 @@ pub struct SourceContext {
 impl SourceContext {
     pub fn from_raw(source: *mut obs_source_t) -> Self {
         Self {
-            inner: unsafe { obs_source_get_ref(source) }
+            inner: unsafe { obs_source_get_ref(source) },
         }
     }
 }
@@ -96,9 +98,7 @@ impl Clone for SourceContext {
 
 impl Drop for SourceContext {
     fn drop(&mut self) {
-        unsafe {
-            obs_source_release(self.inner)
-        }
+        unsafe { obs_source_release(self.inner) }
     }
 }
 
@@ -251,7 +251,8 @@ impl SourceContext {
     }
 
     /// Run a function to do drawing - if the source is a filter.
-    /// This function is wrapped by calls that automatically handle effect-based filter processing.
+    /// This function is wrapped by calls that automatically handle effect-based
+    /// filter processing.
     ///
     /// See [OBS documentation](https://obsproject.com/docs/reference-sources.html#c.obs_source_process_filter_begin)
     ///
@@ -339,9 +340,9 @@ impl AsRef<obs_source_info> for SourceInfo {
 
 /// The SourceInfoBuilder that handles creating the [SourceInfo](https://obsproject.com/docs/reference-sources.html#c.obs_source_info) object.
 ///
-/// For each trait that is implemented for the Source, it needs to be enabled using this builder.
-/// If an struct called `FocusFilter` implements `CreateSource` and `GetNameSource` it would need
-/// to enable those features.
+/// For each trait that is implemented for the Source, it needs to be enabled
+/// using this builder. If an struct called `FocusFilter` implements
+/// `CreateSource` and `GetNameSource` it would need to enable those features.
 ///
 /// ```rs
 /// let source = load_context
@@ -350,7 +351,6 @@ impl AsRef<obs_source_info> for SourceInfo {
 ///  .enable_create()
 ///  .build();
 /// ```
-///
 pub struct SourceInfoBuilder<D: Sourceable> {
     __data: PhantomData<D>,
     info: obs_source_info,

--- a/src/source/traits.rs
+++ b/src/source/traits.rs
@@ -1,3 +1,5 @@
+use obs_sys::{obs_key_event, obs_mouse_event};
+
 use super::context::{CreatableSourceContext, GlobalContext, VideoRenderContext};
 use super::video::VideoDataContext;
 use super::{audio::AudioDataContext, media::MediaState};
@@ -33,6 +35,32 @@ simple_trait!(
 
 pub trait UpdateSource: Sized {
     fn update(&mut self, settings: &mut DataObj, context: &mut GlobalContext);
+}
+
+pub trait MouseWheelSource: Sized {
+    fn mouse_wheel(&mut self, event: obs_mouse_event, xdelta: i32, ydelta: i32);
+}
+
+pub trait MouseClickSource: Sized {
+    fn mouse_click(
+        &mut self,
+        event: obs_mouse_event,
+        button: super::MouseButton,
+        pressed: bool,
+        click_count: u8,
+    );
+}
+
+pub trait MouseMoveSource: Sized {
+    fn mouse_move(&mut self, event: obs_mouse_event, leave: bool);
+}
+
+pub trait KeyClickSource: Sized {
+    fn key_click(&mut self, event: obs_key_event, pressed: bool);
+}
+
+pub trait FocusSource: Sized {
+    fn focus(&mut self, focused: bool);
 }
 
 pub trait VideoRenderSource: Sized {

--- a/src/source/traits.rs
+++ b/src/source/traits.rs
@@ -1,9 +1,9 @@
 use super::context::{CreatableSourceContext, GlobalContext, VideoRenderContext};
-use crate::properties::Properties;
+use super::video::VideoDataContext;
 use super::{audio::AudioDataContext, media::MediaState};
-use super::{video::VideoDataContext};
-use super::{EnumActiveContext, EnumAllContext, SourceType, SourceContext};
+use super::{EnumActiveContext, EnumAllContext, SourceContext, SourceType};
 use crate::data::DataObj;
+use crate::properties::Properties;
 use crate::string::ObsString;
 
 pub trait Sourceable: Sized {
@@ -36,11 +36,7 @@ pub trait UpdateSource: Sized {
 }
 
 pub trait VideoRenderSource: Sized {
-    fn video_render(
-        &mut self,
-        context: &mut GlobalContext,
-        render: &mut VideoRenderContext,
-    );
+    fn video_render(&mut self, context: &mut GlobalContext, render: &mut VideoRenderContext);
 }
 
 pub trait AudioRenderSource: Sized {

--- a/src/source/video.rs
+++ b/src/source/video.rs
@@ -1,10 +1,6 @@
 use obs_sys::{
-    obs_source_frame,
-    video_output_get_width,
-    video_output_get_height,
-    video_output_get_frame_rate,
-    video_output_get_format,
-    video_t,
+    obs_source_frame, video_output_get_format, video_output_get_frame_rate,
+    video_output_get_height, video_output_get_width, video_t,
 };
 
 #[derive(Debug, PartialEq)]
@@ -97,12 +93,12 @@ impl VideoRef {
 
     pub(crate) fn get_width(&self) -> u32 {
         unsafe { video_output_get_width(self.pointer) }
-    } 
+    }
 
     pub(crate) fn get_height(&self) -> u32 {
         unsafe { video_output_get_height(self.pointer) }
     }
-    
+
     pub(crate) fn get_frame_rate(&self) -> f64 {
         unsafe { video_output_get_frame_rate(self.pointer) }
     }

--- a/src/source/video.rs
+++ b/src/source/video.rs
@@ -1,9 +1,11 @@
+use std::mem;
+
 use obs_sys::{
     obs_source_frame, video_output_get_format, video_output_get_frame_rate,
     video_output_get_height, video_output_get_width, video_t,
 };
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug)]
 pub enum VideoFormat {
     Unknown,
     None,
@@ -23,6 +25,16 @@ pub enum VideoFormat {
     I42A,
     YUVA,
     AYUV,
+}
+
+impl PartialEq for VideoFormat {
+    fn eq(&self, other: &Self) -> bool {
+        if matches!(self, VideoFormat::Unknown) || matches!(other, VideoFormat::Unknown) {
+            false
+        } else {
+            mem::discriminant(self) == mem::discriminant(other)
+        }
+    }
 }
 
 impl From<u32> for VideoFormat {
@@ -82,10 +94,12 @@ impl VideoDataContext {
     }
 }
 
+#[allow(unused)]
 pub struct VideoRef {
     pointer: *mut video_t,
 }
 
+#[allow(unused)]
 impl VideoRef {
     pub(crate) unsafe fn from_raw(pointer: *mut video_t) -> Self {
         Self { pointer }

--- a/src/string.rs
+++ b/src/string.rs
@@ -8,8 +8,8 @@ pub enum ObsString {
 
 impl ObsString {
     /// # Safety
-    /// Does no checks for nul terminated strings. This could cause memory overruns if used
-    /// incorrectly.
+    /// Does no checks for nul terminated strings. This could cause memory
+    /// overruns if used incorrectly.
     pub const unsafe fn from_nul_terminted_str(string: &'static str) -> Self {
         Self::Static(string)
     }

--- a/src/string.rs
+++ b/src/string.rs
@@ -16,7 +16,7 @@ impl ObsString {
 
     pub fn as_str(&self) -> &str {
         match self {
-            Self::Static(s) => *s,
+            Self::Static(s) => s,
             Self::Dynamic(s) => s.as_c_str().to_str().unwrap(),
         }
     }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -3,6 +3,10 @@ use std::mem::forget;
 pub trait PtrWrapper: Sized {
     type Pointer;
     /// Wraps the pointer into a **owned** wrapper.
+    ///
+    /// # Safety
+    ///
+    /// Pointer must be valid.
     unsafe fn from_raw(raw: *mut Self::Pointer) -> Self;
 
     /// Returns the inner pointer.


### PR DESCRIPTION
In the process of writing an OBS plugin for [livesplit](http://livesplit.org/) ([source here](https://github.com/P1n3appl3/obs-livesplit)) and a simple [gamepad visualizer plugin](https://github.com/P1n3appl3/obs-gamepad) I found that I needed these features, so I went ahead and added them to `obs-wrapper`. If you'd like to have them upstreamed I'd be happy to clean it up and/or make tweaks. Here's some more detail on the state of the changes:

## Icons

This was pretty straightforward, I didn't know whether to stick the method on `SourceInfoBuilder` or `SourceInfo` so I just did both. It should be mergeable as is.

## Interactable sources

I've checked that all the functions added here work, but this probably isn't what the final api for them should look like. Passing around the raw `obs_mouse_event`/`obs_key_event` is maybe alright, but I'd assume we want a more ergonomic wrapper for pulling out stuff like the modifier keys without doing manual bit testing. If that's out of scope for this crate though then we could merge it with the raw events. Also I can't imagine anyone actually needs `click_count` on the `mouse_click` handler (also i checked and it always returns 1 or 2, and only 1 for release events), so maybe we just drop that from the signature.

## `set_default`

This is more or less an updated version of #15. We still have the issue that there's no function in the obs headers for the array type, so I made that one `unimplemented!()` for now. The feature works (though I've only tested it on integer types so we should probably check that strings/objects are working), but we might want to tweak the signature before merging because it's a bit annoying that you end up needing to specify the type most of the time which means 3 type parameters:
```rust
settings.set_default::<_, i64, _>(obs_string!("width"), 350);
```

## Exposing more raw objects

This was a one-line change (making the `wrapper` module public), which enables taking structs like `Properties` and accessing the inner `*mut obs_properties_t`. This is useful because it lets users of the crate call arbitrary obs_sys functions on the wrapper types from this crate.

Here's an example of how I used it to add buttons to my properties menu, which `obs-wrapper` doesn't support.

```rust
fn get_properties(&mut self) -> Properties {
    let mut props = Properties::new();
    unsafe {
        obs_sys::obs_properties_add_button(
            props.as_ptr_mut(),
            obs_string!("save_splits").as_ptr(),
            obs_string!("Save Splits").as_ptr(),
         Some(save_splits),
        );
    }
...
}

unsafe extern "C" fn save_splits(
    _: *mut obs_sys::obs_properties_t,
    _: *mut obs_sys::obs_property_t,
    data: *mut std::ffi::c_void,
) -> bool {...}
}
```

Obviously it'd be great if we supported more of the plugin api, but I think giving users access to the `obs_sys` types is a good way to let people do complicated things that we don't cover yet.

## Misc.

Before adding these features, I formatted the codebase and cleaned up clippy warnings. If you just want to review the feature additions then I could split those commits out. Just let me know.