### PR TITLE
Fix CI on linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,9 @@ jobs:
         with:
           toolchain: stable
 
-      - run: cargo clippy --all --no-deps -- -D warnings
+      - run: |
+          sudo apt remove libclang1-15
+          cargo clippy --all --no-deps -- -D warnings
 
   build_linux:
     runs-on: ubuntu-latest
@@ -64,6 +66,7 @@ jobs:
           sudo add-apt-repository ppa:obsproject/obs-studio
           sudo apt-get update
           sudo apt-get install obs-studio libxcb-randr0-dev libxcb-ewmh-dev
+          sudo apt remove libclang1-15
 
       - uses: actions-rs/toolchain@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/bennetthardwick/rust-obs-plugins"
 
 [workspace]
 
+
 members = [
   "obs-sys",
   "plugins/*",

--- a/src/source/ffi.rs
+++ b/src/source/ffi.rs
@@ -86,7 +86,7 @@ pub unsafe extern "C" fn create<D: Sourceable>(
     settings: *mut obs_data_t,
     source: *mut obs_source_t,
 ) -> *mut c_void {
-    let mut global = GlobalContext::default();
+    let mut global = GlobalContext;
     let settings = DataObj::from_raw(settings);
     let mut context = CreatableSourceContext::from_raw(settings, &mut global);
     let source_context = SourceContext::from_raw(source);
@@ -113,7 +113,7 @@ pub unsafe extern "C" fn destroy<D>(data: *mut c_void) {
 }
 
 pub unsafe extern "C" fn update<D: UpdateSource>(data: *mut c_void, settings: *mut obs_data_t) {
-    let mut global = GlobalContext::default();
+    let mut global = GlobalContext;
     let data: &mut DataWrapper<D> = &mut *(data as *mut DataWrapper<D>);
     let mut settings = DataObj::from_raw(settings);
     D::update(&mut data.data, &mut settings, &mut global);
@@ -125,8 +125,8 @@ pub unsafe extern "C" fn video_render<D: VideoRenderSource>(
     _effect: *mut gs_effect_t,
 ) {
     let wrapper: &mut DataWrapper<D> = &mut *(data as *mut DataWrapper<D>);
-    let mut global = GlobalContext::default();
-    let mut render = VideoRenderContext::default();
+    let mut global = GlobalContext;
+    let mut render = VideoRenderContext;
     D::video_render(&mut wrapper.data, &mut global, &mut render);
 }
 
@@ -139,7 +139,7 @@ pub unsafe extern "C" fn audio_render<D: AudioRenderSource>(
     _sample_rate: size_t,
 ) -> bool {
     let wrapper: &mut DataWrapper<D> = &mut *(data as *mut DataWrapper<D>);
-    let mut global = GlobalContext::default();
+    let mut global = GlobalContext;
     D::audio_render(&mut wrapper.data, &mut global);
     // TODO: understand what this bool is
     true


### PR DESCRIPTION
- CI failure is caused by different libclang versions (especially libclang-15). I suppose they provide different versions of same header file
- Problem can be fixed by adding `sudo apt remove libclang1-15` to `build_linux` and `cargo clippy` jobs, but there should be better solution
- I was unable to find a way to deal with dependencies on Windows