### PR TITLE
refactor PtrWrapper and add SceneRef

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,7 @@ dependencies = [
  "num-traits",
  "obs-sys",
  "paste",
+ "thiserror",
 ]
 
 [[package]]
@@ -633,18 +634,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e45bcbe8ed29775f228095caf2cd67af7a4ccf756ebff23a306bf3e8b47b24b"
+checksum = "03468839009160513471e86a034bb2c5c0e4baae3b43f79ffc55c4a5427b3297"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.57"
+version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a953cb265bef375dae3de6663da4d3804eee9682ea80d8e2542529b73c531c81"
+checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ obs-sys = { path = "./obs-sys", version = "0.3.0" }
 paste = "0.1.7"
 log = {version = "0.4.11", features = ["std"]}
 num-traits = "0.2.14"
+thiserror = "1.0.58"

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ impl Sourceable for TestSource {
     }
 
     fn get_type() -> SourceType {
-        SourceType::FILTER
+        SourceType::Filter
     }
 
     fn create(create: &mut CreatableSourceContext<Self>, source: SourceContext) -> Self {

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ use obs_wrapper::{
 
 // The module that will handle creating the source.
 struct TestModule {
-    context: ModuleContext
+    context: ModuleRef
 }
 
 // The source that will be shown inside OBS.
@@ -80,11 +80,11 @@ impl GetNameSource for TestSource {
 // Implement the Module trait for TestModule. This will handle the creation of the source and
 // has some methods for telling OBS a bit about itself.
 impl Module for TestModule {
-    fn new(context: ModuleContext) -> Self {
+    fn new(context: ModuleRef) -> Self {
         Self { context }
     }
 
-    fn get_ctx(&self) -> &ModuleContext {
+    fn get_ctx(&self) -> &ModuleRef {
         &self.context
     }
 

--- a/plugins/rnnoise-denoiser-filter/src/lib.rs
+++ b/plugins/rnnoise-denoiser-filter/src/lib.rs
@@ -29,7 +29,7 @@ struct RnnoiseDenoiserFilter {
 }
 
 struct TheModule {
-    context: ModuleContext,
+    context: ModuleRef,
 }
 
 impl Sourceable for RnnoiseDenoiserFilter {
@@ -172,10 +172,10 @@ impl FilterAudioSource for RnnoiseDenoiserFilter {
 }
 
 impl Module for TheModule {
-    fn new(context: ModuleContext) -> Self {
+    fn new(context: ModuleRef) -> Self {
         Self { context }
     }
-    fn get_ctx(&self) -> &ModuleContext {
+    fn get_ctx(&self) -> &ModuleRef {
         &self.context
     }
 

--- a/plugins/rnnoise-denoiser-filter/src/lib.rs
+++ b/plugins/rnnoise-denoiser-filter/src/lib.rs
@@ -39,7 +39,7 @@ impl Sourceable for RnnoiseDenoiserFilter {
     fn get_type() -> SourceType {
         SourceType::FILTER
     }
-    fn create(create: &mut CreatableSourceContext<Self>, _source: SourceContext) -> Self {
+    fn create(create: &mut CreatableSourceContext<Self>, _source: SourceRef) -> Self {
         let (sample_rate, channels) =
             create.with_audio(|audio| (audio.sample_rate(), audio.channels()));
 

--- a/plugins/rnnoise-denoiser-filter/src/lib.rs
+++ b/plugins/rnnoise-denoiser-filter/src/lib.rs
@@ -37,7 +37,7 @@ impl Sourceable for RnnoiseDenoiserFilter {
         obs_string!("rnnoise_noise_suppression_filter")
     }
     fn get_type() -> SourceType {
-        SourceType::FILTER
+        SourceType::Filter
     }
     fn create(create: &mut CreatableSourceContext<Self>, _source: SourceRef) -> Self {
         let (sample_rate, channels) =

--- a/plugins/scroll-focus-filter/src/lib.rs
+++ b/plugins/scroll-focus-filter/src/lib.rs
@@ -60,7 +60,7 @@ impl Drop for ScrollFocusFilter {
 }
 
 struct TheModule {
-    context: ModuleContext,
+    context: ModuleRef,
 }
 
 impl Sourceable for ScrollFocusFilter {
@@ -382,10 +382,10 @@ impl UpdateSource for ScrollFocusFilter {
 }
 
 impl Module for TheModule {
-    fn new(context: ModuleContext) -> Self {
+    fn new(context: ModuleRef) -> Self {
         Self { context }
     }
-    fn get_ctx(&self) -> &ModuleContext {
+    fn get_ctx(&self) -> &ModuleRef {
         &self.context
     }
 

--- a/plugins/scroll-focus-filter/src/lib.rs
+++ b/plugins/scroll-focus-filter/src/lib.rs
@@ -17,7 +17,7 @@ enum ServerMessage {
 }
 
 struct ScrollFocusFilter {
-    source: SourceContext,
+    source: SourceRef,
     effect: GraphicsEffect,
 
     base_dimension: GraphicsEffectVec2Param,
@@ -70,7 +70,7 @@ impl Sourceable for ScrollFocusFilter {
     fn get_type() -> SourceType {
         SourceType::FILTER
     }
-    fn create(create: &mut CreatableSourceContext<Self>, mut source: SourceContext) -> Self {
+    fn create(create: &mut CreatableSourceContext<Self>, mut source: SourceRef) -> Self {
         let mut effect = GraphicsEffect::from_effect_string(
             obs_string!(include_str!("./crop_filter.effect")),
             obs_string!("crop_filter.effect"),

--- a/plugins/scroll-focus-filter/src/lib.rs
+++ b/plugins/scroll-focus-filter/src/lib.rs
@@ -68,7 +68,7 @@ impl Sourceable for ScrollFocusFilter {
         obs_string!("scroll_focus_filter")
     }
     fn get_type() -> SourceType {
-        SourceType::FILTER
+        SourceType::Filter
     }
     fn create(create: &mut CreatableSourceContext<Self>, mut source: SourceRef) -> Self {
         let mut effect = GraphicsEffect::from_effect_string(

--- a/src/graphics/display.rs
+++ b/src/graphics/display.rs
@@ -1,21 +1,111 @@
-use obs_sys::{obs_display_destroy, obs_display_enabled, obs_display_resize, obs_display_t};
+use obs_sys::{
+    obs_display_add_draw_callback, obs_display_destroy, obs_display_enabled,
+    obs_display_remove_draw_callback, obs_display_resize, obs_display_t, obs_render_main_texture,
+};
 
 pub struct DisplayRef {
-    inner: *mut obs_display_t
+    inner: *mut obs_display_t,
 }
 
 impl_ptr_wrapper!(@ptr: inner, DisplayRef, obs_display_t, @identity, obs_display_destroy);
 
 impl DisplayRef {
     pub fn enabled(&self) -> bool {
-        unsafe {
-            obs_display_enabled(self.inner)
-        }
+        unsafe { obs_display_enabled(self.inner) }
     }
 
     pub fn set_size(&self, cx: u32, cy: u32) {
+        unsafe { obs_display_resize(self.inner, cx, cy) }
+    }
+
+    pub fn add_draw_callback<'a, S: DrawCallback>(&'a self, callback: S) -> DrawCallbackId<'a, S> {
+        let data = Box::into_raw(Box::new(callback));
+        let callback = draw_callback::<S>;
         unsafe {
-            obs_display_resize(self.inner, cx, cy)
+            obs_display_add_draw_callback(self.inner, Some(callback), data as *mut std::ffi::c_void)
+        }
+        DrawCallbackId::new(data, callback as *const _, self.inner)
+    }
+
+    pub fn remove_draw_callback<S: DrawCallback>(&self, data: DrawCallbackId<S>) -> S {
+        data.take(self)
+    }
+}
+
+pub struct RenderMainTexture;
+
+impl DrawCallback for RenderMainTexture {
+    fn draw(&self, _cx: u32, _cy: u32) {
+        unsafe { obs_render_main_texture() }
+    }
+}
+
+pub trait DrawCallback {
+    fn draw(&self, cx: u32, cy: u32);
+}
+
+pub unsafe extern "C" fn draw_callback<S: DrawCallback>(
+    data: *mut std::ffi::c_void,
+    cx: u32,
+    cy: u32,
+) {
+    let callback = &*(data as *const S);
+    callback.draw(cx, cy);
+}
+
+pub struct DrawCallbackId<'a, S> {
+    data: *mut S,
+    callback: *const std::ffi::c_void,
+    display: *mut obs_display_t,
+    _marker: std::marker::PhantomData<&'a S>,
+}
+
+impl<'a, S> DrawCallbackId<'a, S> {
+    pub fn new(
+        data: *mut S,
+        callback: *const std::ffi::c_void,
+        display: *mut obs_display_t,
+    ) -> Self {
+        DrawCallbackId {
+            data,
+            callback,
+            display,
+            _marker: std::marker::PhantomData,
+        }
+    }
+
+    pub fn take(self, display: &DisplayRef) -> S {
+        assert_eq!(self.display, display.inner);
+        let ptr = self.data;
+        unsafe {
+            obs_display_add_draw_callback(
+                self.display,
+                Some(std::mem::transmute(self.callback)),
+                ptr as *mut std::ffi::c_void,
+            )
+        }
+        std::mem::forget(self);
+        unsafe { *Box::from_raw(ptr) }
+    }
+
+    /// Forget the callback and keep it alive forever.
+    /// As long as the underlying display is alive, the callback will be called.
+    /// If the display is destroyed, the callback will be also dropped.
+    pub fn forever(self) {
+        std::mem::forget(self);
+    }
+}
+
+impl<'a, S> Drop for DrawCallbackId<'a, S> {
+    fn drop(&mut self) {
+        unsafe {
+            // we don't check validity of the display here
+            obs_display_remove_draw_callback(
+                self.display,
+                Some(std::mem::transmute(self.callback)),
+                self.data as *mut std::ffi::c_void,
+            );
+            drop(Box::from_raw(self.data));
         }
     }
 }

--- a/src/graphics/display.rs
+++ b/src/graphics/display.rs
@@ -1,8 +1,88 @@
 use obs_sys::{
     obs_display_add_draw_callback, obs_display_destroy, obs_display_enabled,
-    obs_display_remove_draw_callback, obs_display_resize, obs_display_t, obs_render_main_texture,
+    obs_display_remove_draw_callback, obs_display_resize, obs_display_set_background_color,
+    obs_display_set_enabled, obs_display_size, obs_display_t, obs_render_main_texture,
 };
 
+use super::GraphicsColorFormat;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Color {
+    pub r: u8,
+    pub g: u8,
+    pub b: u8,
+    pub a: u8,
+}
+
+fn srgb_nonlinear_to_linear(c: f32) -> f32 {
+    if c <= 0.04045 {
+        c / 12.92
+    } else {
+        ((c + 0.055) / 1.055).powf(2.4)
+    }
+}
+fn srgb_linear_to_nonlinear(c: f32) -> f32 {
+    if c <= 0.0031308 {
+        c * 12.92
+    } else {
+        1.055 * c.powf(1.0 / 2.4) - 0.055
+    }
+}
+impl Color {
+    pub const BLACK: Color = Color::new(0, 0, 0, 255);
+    pub const WHITE: Color = Color::new(255, 255, 255, 255);
+    pub const RED: Color = Color::new(255, 0, 0, 255);
+    pub const GREEN: Color = Color::new(0, 255, 0, 255);
+    pub const BLUE: Color = Color::new(0, 0, 255, 255);
+
+    pub const fn new(r: u8, g: u8, b: u8, a: u8) -> Self {
+        Color { r, g, b, a }
+    }
+
+    pub fn as_format(self, format: GraphicsColorFormat) -> u32 {
+        match format {
+            GraphicsColorFormat::RGBA => self.as_rgba(),
+            GraphicsColorFormat::BGRA => self.as_bgra(),
+            _ => unimplemented!("unsupported color format"),
+        }
+    }
+
+    pub fn as_rgba(self) -> u32 {
+        u32::from_ne_bytes([self.r, self.g, self.b, self.a])
+    }
+
+    pub fn as_bgra(self) -> u32 {
+        u32::from_ne_bytes([self.b, self.g, self.r, self.a])
+    }
+
+    /// gs_float3_srgb_nonlinear_to_linear
+    pub fn srgb_nonlinear_to_linear(self) -> Self {
+        let r = srgb_nonlinear_to_linear(self.r as f32 / 255.0);
+        let g = srgb_nonlinear_to_linear(self.g as f32 / 255.0);
+        let b = srgb_nonlinear_to_linear(self.b as f32 / 255.0);
+        Color {
+            r: (r * 255.0) as u8,
+            g: (g * 255.0) as u8,
+            b: (b * 255.0) as u8,
+            a: self.a,
+        }
+    }
+
+    pub fn srgb_linear_to_nonlinear(self) -> Self {
+        let r = srgb_linear_to_nonlinear(self.r as f32 / 255.0);
+        let g = srgb_linear_to_nonlinear(self.g as f32 / 255.0);
+        let b = srgb_linear_to_nonlinear(self.b as f32 / 255.0);
+        Color {
+            r: (r * 255.0) as u8,
+            g: (g * 255.0) as u8,
+            b: (b * 255.0) as u8,
+            a: self.a,
+        }
+    }
+}
+
+/// A reference to a display, inner pointer is not managed by reference count.
+/// So no `Clone` is implemented. you might want to use `Arc<DisplayRef>` if you need to clone it.
 pub struct DisplayRef {
     inner: *mut obs_display_t,
 }
@@ -14,8 +94,23 @@ impl DisplayRef {
         unsafe { obs_display_enabled(self.inner) }
     }
 
+    pub fn set_enabled(&self, enabled: bool) {
+        unsafe { obs_display_set_enabled(self.inner, enabled) }
+    }
+
+    pub fn size(&self) -> (u32, u32) {
+        let mut cx = 0;
+        let mut cy = 0;
+        unsafe { obs_display_size(self.inner, &mut cx, &mut cy) }
+        (cx, cy)
+    }
+
     pub fn set_size(&self, cx: u32, cy: u32) {
         unsafe { obs_display_resize(self.inner, cx, cy) }
+    }
+
+    pub fn set_background_color(&self, color: Color) {
+        unsafe { obs_display_set_background_color(self.inner, color.as_rgba()) }
     }
 
     pub fn add_draw_callback<S: DrawCallback>(&self, callback: S) -> DrawCallbackId<'_, S> {

--- a/src/graphics/display.rs
+++ b/src/graphics/display.rs
@@ -1,0 +1,21 @@
+use obs_sys::{obs_display_destroy, obs_display_enabled, obs_display_resize, obs_display_t};
+
+pub struct DisplayRef {
+    inner: *mut obs_display_t
+}
+
+impl_ptr_wrapper!(@ptr: inner, DisplayRef, obs_display_t, @identity, obs_display_destroy);
+
+impl DisplayRef {
+    pub fn enabled(&self) -> bool {
+        unsafe {
+            obs_display_enabled(self.inner)
+        }
+    }
+
+    pub fn set_size(&self, cx: u32, cy: u32) {
+        unsafe {
+            obs_display_resize(self.inner, cx, cy)
+        }
+    }
+}

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -221,7 +221,7 @@ macro_rules! impl_graphics_effects {
                     fn try_from(effect: GraphicsEffectParam) -> Result<Self> {
                         match effect.shader_type {
                             ShaderParamType::[<$t>] => Ok([<GraphicsEffect $t Param>] { effect }),
-                            _ => Err(Error),
+                            _ => Err(Error::EnumOutOfRange("ShaderParamType", effect.shader_type as _)),
                         }
                     }
                 }
@@ -700,7 +700,7 @@ impl<'tex> MappedTexture<'tex> {
             gs_texture_map(tex.as_ptr(), &mut ptr, &mut linesize)
         });
         if !map_result {
-            return Err(Error);
+            return Err(Error::ObsError(-1));
         }
         let len = (linesize * tex.height()) as usize;
         Ok(Self { tex, ptr, len })

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -1,3 +1,5 @@
+pub mod display;
+
 use crate::{Error, Result};
 use core::convert::TryFrom;
 use core::ptr::null_mut;

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -1,6 +1,6 @@
 pub mod display;
 
-use crate::{Error, Result};
+use crate::{native_enum, Error, Result};
 use core::convert::TryFrom;
 use core::ptr::null_mut;
 use obs_sys::{
@@ -72,62 +72,21 @@ impl Drop for GraphicsGuard {
     }
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum ShaderParamType {
-    Unknown,
-    Bool,
-    Float,
-    Int,
-    String,
-    Vec2,
-    Vec3,
-    Vec4,
-    Int2,
-    Int3,
-    Int4,
-    Mat4,
-    Texture,
-}
-
-impl ShaderParamType {
-    pub fn as_raw(&self) -> gs_shader_param_type {
-        match self {
-            ShaderParamType::Unknown => gs_shader_param_type_GS_SHADER_PARAM_UNKNOWN,
-            ShaderParamType::Bool => gs_shader_param_type_GS_SHADER_PARAM_BOOL,
-            ShaderParamType::Float => gs_shader_param_type_GS_SHADER_PARAM_FLOAT,
-            ShaderParamType::Int => gs_shader_param_type_GS_SHADER_PARAM_INT,
-            ShaderParamType::String => gs_shader_param_type_GS_SHADER_PARAM_STRING,
-            ShaderParamType::Vec2 => gs_shader_param_type_GS_SHADER_PARAM_VEC2,
-            ShaderParamType::Vec3 => gs_shader_param_type_GS_SHADER_PARAM_VEC3,
-            ShaderParamType::Vec4 => gs_shader_param_type_GS_SHADER_PARAM_VEC4,
-            ShaderParamType::Int2 => gs_shader_param_type_GS_SHADER_PARAM_INT2,
-            ShaderParamType::Int3 => gs_shader_param_type_GS_SHADER_PARAM_INT3,
-            ShaderParamType::Int4 => gs_shader_param_type_GS_SHADER_PARAM_INT4,
-            ShaderParamType::Mat4 => gs_shader_param_type_GS_SHADER_PARAM_MATRIX4X4,
-            ShaderParamType::Texture => gs_shader_param_type_GS_SHADER_PARAM_TEXTURE,
-        }
-    }
-
-    #[allow(non_upper_case_globals)]
-    pub fn from_raw(param_type: gs_shader_param_type) -> Self {
-        match param_type {
-            gs_shader_param_type_GS_SHADER_PARAM_UNKNOWN => ShaderParamType::Unknown,
-            gs_shader_param_type_GS_SHADER_PARAM_BOOL => ShaderParamType::Bool,
-            gs_shader_param_type_GS_SHADER_PARAM_FLOAT => ShaderParamType::Float,
-            gs_shader_param_type_GS_SHADER_PARAM_INT => ShaderParamType::Int,
-            gs_shader_param_type_GS_SHADER_PARAM_STRING => ShaderParamType::String,
-            gs_shader_param_type_GS_SHADER_PARAM_VEC2 => ShaderParamType::Vec2,
-            gs_shader_param_type_GS_SHADER_PARAM_VEC3 => ShaderParamType::Vec3,
-            gs_shader_param_type_GS_SHADER_PARAM_VEC4 => ShaderParamType::Vec4,
-            gs_shader_param_type_GS_SHADER_PARAM_INT2 => ShaderParamType::Int2,
-            gs_shader_param_type_GS_SHADER_PARAM_INT3 => ShaderParamType::Int3,
-            gs_shader_param_type_GS_SHADER_PARAM_INT4 => ShaderParamType::Int4,
-            gs_shader_param_type_GS_SHADER_PARAM_MATRIX4X4 => ShaderParamType::Mat4,
-            gs_shader_param_type_GS_SHADER_PARAM_TEXTURE => ShaderParamType::Texture,
-            _ => panic!("Invalid param_type!"),
-        }
-    }
-}
+native_enum!(ShaderParamType, gs_shader_param_type {
+    Unknown => GS_SHADER_PARAM_UNKNOWN,
+    Bool => GS_SHADER_PARAM_BOOL,
+    Float => GS_SHADER_PARAM_FLOAT,
+    Int => GS_SHADER_PARAM_INT,
+    String => GS_SHADER_PARAM_STRING,
+    Vec2 => GS_SHADER_PARAM_VEC2,
+    Vec3 => GS_SHADER_PARAM_VEC3,
+    Vec4 => GS_SHADER_PARAM_VEC4,
+    Int2 => GS_SHADER_PARAM_INT2,
+    Int3 => GS_SHADER_PARAM_INT3,
+    Int4 => GS_SHADER_PARAM_INT4,
+    Mat4 => GS_SHADER_PARAM_MATRIX4X4,
+    Texture => GS_SHADER_PARAM_TEXTURE,
+});
 
 pub struct GraphicsEffect {
     raw: *mut gs_effect_t,
@@ -192,7 +151,7 @@ impl GraphicsEffectParam {
         let mut info = gs_effect_param_info::default();
         gs_effect_get_param_info(raw, &mut info);
 
-        let shader_type = ShaderParamType::from_raw(info.type_);
+        let shader_type = ShaderParamType::from_raw(info.type_).unwrap();
         let name = CString::from(CStr::from_ptr(info.name))
             .into_string()
             .unwrap_or_else(|_| String::from("{unknown-param-name}"));
@@ -263,65 +222,25 @@ impl GraphicsEffectTextureParam {
     }
 }
 
-pub enum GraphicsAddressMode {
-    Clamp,
-    Wrap,
-    Mirror,
-    Border,
-    MirrorOnce,
-}
+native_enum!(GraphicsAddressMode, gs_address_mode {
+    Clamp => GS_ADDRESS_CLAMP,
+    Wrap => GS_ADDRESS_WRAP,
+    Mirror => GS_ADDRESS_MIRROR,
+    Border => GS_ADDRESS_BORDER,
+    MirrorOnce => GS_ADDRESS_MIRRORONCE,
+});
 
-impl GraphicsAddressMode {
-    pub fn as_raw(&self) -> gs_address_mode {
-        match self {
-            GraphicsAddressMode::Clamp => gs_address_mode_GS_ADDRESS_CLAMP,
-            GraphicsAddressMode::Wrap => gs_address_mode_GS_ADDRESS_WRAP,
-            GraphicsAddressMode::Mirror => gs_address_mode_GS_ADDRESS_MIRROR,
-            GraphicsAddressMode::Border => gs_address_mode_GS_ADDRESS_BORDER,
-            GraphicsAddressMode::MirrorOnce => gs_address_mode_GS_ADDRESS_MIRRORONCE,
-        }
-    }
-}
-
-pub enum GraphicsSampleFilter {
-    Point,
-    Linear,
-    Anisotropic,
-    MinMagPointMipLinear,
-    MinPointMagLinearMipPoint,
-    MinPointMagMipLinear,
-    MinLinearMapMipPoint,
-    MinLinearMagPointMipLinear,
-    MinMagLinearMipPoint,
-}
-
-impl GraphicsSampleFilter {
-    fn as_raw(&self) -> gs_sample_filter {
-        match self {
-            GraphicsSampleFilter::Point => gs_sample_filter_GS_FILTER_POINT,
-            GraphicsSampleFilter::Linear => gs_sample_filter_GS_FILTER_LINEAR,
-            GraphicsSampleFilter::Anisotropic => gs_sample_filter_GS_FILTER_ANISOTROPIC,
-            GraphicsSampleFilter::MinMagPointMipLinear => {
-                gs_sample_filter_GS_FILTER_MIN_MAG_POINT_MIP_LINEAR
-            }
-            GraphicsSampleFilter::MinPointMagLinearMipPoint => {
-                gs_sample_filter_GS_FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT
-            }
-            GraphicsSampleFilter::MinPointMagMipLinear => {
-                gs_sample_filter_GS_FILTER_MIN_POINT_MAG_MIP_LINEAR
-            }
-            GraphicsSampleFilter::MinLinearMapMipPoint => {
-                gs_sample_filter_GS_FILTER_MIN_LINEAR_MAG_MIP_POINT
-            }
-            GraphicsSampleFilter::MinLinearMagPointMipLinear => {
-                gs_sample_filter_GS_FILTER_MIN_LINEAR_MAG_POINT_MIP_LINEAR
-            }
-            GraphicsSampleFilter::MinMagLinearMipPoint => {
-                gs_sample_filter_GS_FILTER_MIN_MAG_LINEAR_MIP_POINT
-            }
-        }
-    }
-}
+native_enum!(GraphicsSampleFilter, gs_sample_filter {
+    Point => GS_FILTER_POINT,
+    Linear => GS_FILTER_LINEAR,
+    Anisotropic => GS_FILTER_ANISOTROPIC,
+    MinMagPointMipLinear => GS_FILTER_MIN_MAG_POINT_MIP_LINEAR,
+    MinPointMagLinearMipPoint => GS_FILTER_MIN_POINT_MAG_LINEAR_MIP_POINT,
+    MinPointMagMipLinear => GS_FILTER_MIN_POINT_MAG_MIP_LINEAR,
+    MinLinearMapMipPoint => GS_FILTER_MIN_LINEAR_MAG_MIP_POINT,
+    MinLinearMagPointMipLinear => GS_FILTER_MIN_LINEAR_MAG_POINT_MIP_LINEAR,
+    MinMagLinearMipPoint => GS_FILTER_MIN_MAG_LINEAR_MIP_POINT,
+});
 
 pub struct GraphicsSamplerInfo {
     info: gs_sampler_info,
@@ -398,72 +317,32 @@ impl GraphicsEffectContext {
     }
 }
 
-#[derive(Debug, Eq, PartialEq, Clone, Copy)]
-pub enum GraphicsColorFormat {
-    UNKNOWN,
-    A8,
-    R8,
-    RGBA,
-    BGRX,
-    BGRA,
-    R10G10B10A2,
-    RGBA16,
-    R16,
-    RGBA16F,
-    RGBA32F,
-    RG16F,
-    RG32F,
-    R16F,
-    R32F,
-    DXT1,
-    DXT3,
-    DXT5,
-    R8G8,
-}
+native_enum!(GraphicsColorFormat, gs_color_format {
+    UNKNOWN => GS_UNKNOWN,
+    A8 => GS_A8,
+    R8 => GS_R8,
+    RGBA => GS_RGBA,
+    BGRX => GS_BGRX,
+    BGRA => GS_BGRA,
+    R10G10B10A2 => GS_R10G10B10A2,
+    RGBA16 => GS_RGBA16,
+    R16 => GS_R16,
+    RGBA16F => GS_RGBA16F,
+    RGBA32F => GS_RGBA32F,
+    RG16F => GS_RG16F,
+    RG32F => GS_RG32F,
+    R16F => GS_R16F,
+    R32F => GS_R32F,
+    DXT1 => GS_DXT1,
+    DXT3 => GS_DXT3,
+    DXT5 => GS_DXT5,
+    R8G8 => GS_R8G8,
+});
 
-impl GraphicsColorFormat {
-    pub fn as_raw(&self) -> gs_color_format {
-        match self {
-            GraphicsColorFormat::UNKNOWN => gs_color_format_GS_UNKNOWN,
-            GraphicsColorFormat::A8 => gs_color_format_GS_A8,
-            GraphicsColorFormat::R8 => gs_color_format_GS_R8,
-            GraphicsColorFormat::RGBA => gs_color_format_GS_RGBA,
-            GraphicsColorFormat::BGRX => gs_color_format_GS_BGRX,
-            GraphicsColorFormat::BGRA => gs_color_format_GS_BGRA,
-            GraphicsColorFormat::R10G10B10A2 => gs_color_format_GS_R10G10B10A2,
-            GraphicsColorFormat::RGBA16 => gs_color_format_GS_RGBA16,
-            GraphicsColorFormat::R16 => gs_color_format_GS_R16,
-            GraphicsColorFormat::RGBA16F => gs_color_format_GS_RGBA16F,
-            GraphicsColorFormat::RGBA32F => gs_color_format_GS_RGBA32F,
-            GraphicsColorFormat::RG16F => gs_color_format_GS_RG16F,
-            GraphicsColorFormat::RG32F => gs_color_format_GS_RG32F,
-            GraphicsColorFormat::R16F => gs_color_format_GS_R16F,
-            GraphicsColorFormat::R32F => gs_color_format_GS_R32F,
-            GraphicsColorFormat::DXT1 => gs_color_format_GS_DXT1,
-            GraphicsColorFormat::DXT3 => gs_color_format_GS_DXT3,
-            GraphicsColorFormat::DXT5 => gs_color_format_GS_DXT5,
-            GraphicsColorFormat::R8G8 => gs_color_format_GS_R8G8,
-        }
-    }
-}
-
-pub enum GraphicsAllowDirectRendering {
-    NoDirectRendering,
-    AllowDirectRendering,
-}
-
-impl GraphicsAllowDirectRendering {
-    pub fn as_raw(&self) -> obs_allow_direct_render {
-        match self {
-            GraphicsAllowDirectRendering::NoDirectRendering => {
-                obs_allow_direct_render_OBS_NO_DIRECT_RENDERING
-            }
-            GraphicsAllowDirectRendering::AllowDirectRendering => {
-                obs_allow_direct_render_OBS_ALLOW_DIRECT_RENDERING
-            }
-        }
-    }
-}
+native_enum!(GraphicsAllowDirectRendering, obs_allow_direct_render {
+    NoDirectRendering => OBS_NO_DIRECT_RENDERING,
+    AllowDirectRendering => OBS_ALLOW_DIRECT_RENDERING,
+});
 
 macro_rules! vector_impls {
     ($($rust_name: ident, $name:ident => $($component:ident)*,)*) => (

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,12 +52,12 @@
 //!     }
 //!
 //!     fn get_type() -> SourceType {
-//!         SourceType::FILTER
+//!         SourceType::Filter
 //!     }
 //!
 //!     fn create(
 //!         create: &mut CreatableSourceContext<Self>,
-//!         _source: SourceContext
+//!         _source: SourceRef
 //!     ) -> Self {
 //!         Self
 //!     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,9 @@
 /// Raw bindings of OBS C API
 pub use obs_sys;
 
+/// FFI pointer wrapper
+#[macro_use]
+pub mod wrapper;
 /// `obs_data_t` handling
 pub mod data;
 /// Tools required for manipulating graphics in OBS
@@ -144,8 +147,6 @@ pub mod result;
 pub mod source;
 /// String macros
 pub mod string;
-/// FFI pointer wrapper
-pub mod wrapper;
 
 mod native_enum;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@
 //!
 //! // The module that will handle creating the source.
 //! struct TestModule {
-//!     context: ModuleContext
+//!     context: ModuleRef
 //! };
 //!
 //! // The source that will be shown inside OBS.
@@ -73,11 +73,11 @@
 //! // Implement the Module trait for TestModule. This will handle the creation
 //! // of the source and has some methods for telling OBS a bit about itself.
 //! impl Module for TestModule {
-//!     fn new(context: ModuleContext) -> Self {
+//!     fn new(context: ModuleRef) -> Self {
 //!         Self { context }
 //!     }
 //!
-//!     fn get_ctx(&self) -> &ModuleContext {
+//!     fn get_ctx(&self) -> &ModuleRef {
 //!         &self.context
 //!     }
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,10 +138,10 @@ pub mod module;
 pub mod output;
 /// Tools for creating properties
 pub mod properties;
-/// Tools for creating sources
-pub mod source;
 /// Error handling
 pub mod result;
+/// Tools for creating sources
+pub mod source;
 /// String macros
 pub mod string;
 /// FFI pointer wrapper

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,6 +140,8 @@ pub mod output;
 pub mod properties;
 /// Tools for creating sources
 pub mod source;
+/// Error handling
+pub mod result;
 /// String macros
 pub mod string;
 /// FFI pointer wrapper
@@ -155,15 +157,4 @@ pub mod prelude {
     pub use crate::string::*;
 }
 
-#[derive(Debug)]
-pub struct Error;
-
-impl std::error::Error for Error {}
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "OBS Error")
-    }
-}
-
-pub type Result<T> = std::result::Result<T, Error>;
+pub use result::{Error, Result};

--- a/src/media/state.rs
+++ b/src/media/state.rs
@@ -6,45 +6,17 @@ use obs_sys::{
     obs_media_state_OBS_MEDIA_STATE_STOPPED,
 };
 
+use crate::native_enum;
+
+native_enum!(
 /// OBS media state
-#[derive(Debug, Eq, PartialEq, Copy, Clone)]
-pub enum MediaState {
-    None,
-    Playing,
-    Opening,
-    Buffering,
-    Paused,
-    Stopped,
-    Ended,
-    Error,
-}
-
-impl MediaState {
-    #[allow(non_upper_case_globals)]
-    pub fn from_native(state: obs_media_state) -> Option<Self> {
-        match state {
-            obs_media_state_OBS_MEDIA_STATE_NONE => Some(Self::None),
-            obs_media_state_OBS_MEDIA_STATE_PLAYING => Some(Self::Playing),
-            obs_media_state_OBS_MEDIA_STATE_OPENING => Some(Self::Opening),
-            obs_media_state_OBS_MEDIA_STATE_BUFFERING => Some(Self::Buffering),
-            obs_media_state_OBS_MEDIA_STATE_PAUSED => Some(Self::Paused),
-            obs_media_state_OBS_MEDIA_STATE_STOPPED => Some(Self::Stopped),
-            obs_media_state_OBS_MEDIA_STATE_ENDED => Some(Self::Ended),
-            obs_media_state_OBS_MEDIA_STATE_ERROR => Some(Self::Error),
-            _ => None,
-        }
-    }
-
-    pub fn to_native(self) -> obs_media_state {
-        match self {
-            Self::None => obs_media_state_OBS_MEDIA_STATE_NONE,
-            Self::Playing => obs_media_state_OBS_MEDIA_STATE_PLAYING,
-            Self::Opening => obs_media_state_OBS_MEDIA_STATE_OPENING,
-            Self::Buffering => obs_media_state_OBS_MEDIA_STATE_BUFFERING,
-            Self::Paused => obs_media_state_OBS_MEDIA_STATE_PAUSED,
-            Self::Stopped => obs_media_state_OBS_MEDIA_STATE_STOPPED,
-            Self::Ended => obs_media_state_OBS_MEDIA_STATE_ENDED,
-            Self::Error => obs_media_state_OBS_MEDIA_STATE_ERROR,
-        }
-    }
-}
+MediaState, obs_media_state {
+    None => OBS_MEDIA_STATE_NONE,
+    Playing => OBS_MEDIA_STATE_PLAYING,
+    Opening => OBS_MEDIA_STATE_OPENING,
+    Buffering => OBS_MEDIA_STATE_BUFFERING,
+    Paused => OBS_MEDIA_STATE_PAUSED,
+    Stopped => OBS_MEDIA_STATE_STOPPED,
+    Ended => OBS_MEDIA_STATE_ENDED,
+    Error => OBS_MEDIA_STATE_ERROR,
+});

--- a/src/module.rs
+++ b/src/module.rs
@@ -169,7 +169,7 @@ impl std::fmt::Debug for ModuleRef {
 
 impl ModuleRef {
     /// # Safety
-    /// Creates a ModuleContext from a pointer to the raw obs_module data which
+    /// Creates a ModuleRef from a pointer to the raw obs_module data which
     /// if modified could cause UB.
     pub fn from_raw(raw: *mut obs_module_t) -> Result<Self> {
         if raw.is_null() {

--- a/src/module.rs
+++ b/src/module.rs
@@ -152,6 +152,9 @@ macro_rules! obs_register_module {
     };
 }
 
+#[deprecated = "use `ModuleRef` instead"]
+pub type ModuleContext = ModuleRef;
+
 pub struct ModuleRef {
     raw: *mut obs_module_t,
 }

--- a/src/output/context.rs
+++ b/src/output/context.rs
@@ -57,7 +57,7 @@ extern "C" fn enum_proc(params: *mut std::ffi::c_void, output: *mut obs_output_t
 impl OutputContext {
     pub fn new(id: ObsString, name: ObsString, settings: Option<DataObj<'_>>) -> Self {
         let settings = match settings {
-            Some(mut data) => data.as_ptr_mut(),
+            Some(data) => unsafe { data.as_ptr_mut() },
             None => std::ptr::null_mut(),
         };
         let output = unsafe {

--- a/src/output/context.rs
+++ b/src/output/context.rs
@@ -14,38 +14,28 @@ use obs_sys::{
 
 use crate::hotkey::HotkeyCallbacks;
 use crate::media::{audio::AudioRef, video::VideoRef};
+use crate::string::TryIntoObsString;
 use crate::{hotkey::Hotkey, prelude::DataObj, string::ObsString, wrapper::PtrWrapper};
+use crate::{Error, Result};
+
+#[deprecated = "use `OutputRef` instead"]
+pub type OutputContext = OutputRef;
 
 /// Context wrapping an OBS output - video / audio elements which are displayed
 /// to the screen.
 ///
 /// See [OBS documentation](https://obsproject.com/docs/reference-outputs.html#c.obs_output_t)
-pub struct OutputContext {
+pub struct OutputRef {
     pub(crate) inner: *mut obs_output_t,
 }
 
-impl OutputContext {
-    /// # Safety
-    ///
-    /// Pointer must be valid.
-    pub unsafe fn from_raw(output: *mut obs_output_t) -> Self {
-        Self {
-            inner: obs_output_get_ref(output),
-        }
-    }
-}
-
-impl Clone for OutputContext {
-    fn clone(&self) -> Self {
-        unsafe { Self::from_raw(self.inner) }
-    }
-}
-
-impl Drop for OutputContext {
-    fn drop(&mut self) {
-        unsafe { obs_output_release(self.inner) }
-    }
-}
+impl_ptr_wrapper!(
+    @ptr: inner,
+    OutputRef,
+    obs_output_t,
+    obs_output_get_ref,
+    obs_output_release
+);
 
 extern "C" fn enum_proc(params: *mut std::ffi::c_void, output: *mut obs_output_t) -> bool {
     let mut v = unsafe { Box::<Vec<*mut obs_output_t>>::from_raw(params as *mut _) };
@@ -54,8 +44,8 @@ extern "C" fn enum_proc(params: *mut std::ffi::c_void, output: *mut obs_output_t
     true
 }
 
-impl OutputContext {
-    pub fn new(id: ObsString, name: ObsString, settings: Option<DataObj<'_>>) -> Self {
+impl OutputRef {
+    pub fn new(id: ObsString, name: ObsString, settings: Option<DataObj<'_>>) -> Result<Self> {
         let settings = match settings {
             Some(data) => unsafe { data.as_ptr_mut() },
             None => std::ptr::null_mut(),
@@ -64,18 +54,19 @@ impl OutputContext {
             obs_output_create(id.as_ptr(), name.as_ptr(), settings, std::ptr::null_mut())
         };
 
-        unsafe { Self::from_raw(output) }
+        unsafe { Self::from_raw_unchecked(output) }.ok_or(Error::NulPointer("obs_output_cretae"))
     }
     pub fn all_outputs() -> Vec<Self> {
         let outputs = Vec::<*mut obs_output_t>::new();
         let params = Box::into_raw(Box::new(outputs));
         unsafe {
+            // `obs_enum_outputs` would return `weak_ref`, so `get_ref` needed
             obs_enum_outputs(Some(enum_proc), params as *mut _);
         }
         let outputs = unsafe { Box::from_raw(params) };
         outputs
             .into_iter()
-            .map(|i| unsafe { OutputContext::from_raw(i) })
+            .filter_map(OutputRef::from_raw)
             .collect()
     }
     pub fn all_types() -> Vec<String> {
@@ -96,26 +87,12 @@ impl OutputContext {
         types
     }
 
-    pub fn output_id(&self) -> Option<&str> {
-        unsafe {
-            let ptr = obs_output_get_id(self.inner);
-            if ptr.is_null() {
-                None
-            } else {
-                Some(CStr::from_ptr(ptr).to_str().unwrap())
-            }
-        }
+    pub fn output_id(&self) -> Result<ObsString> {
+        unsafe { obs_output_get_id(self.inner) }.try_into_obs_string()
     }
 
-    pub fn name(&self) -> Option<&str> {
-        unsafe {
-            let ptr = obs_output_get_name(self.inner);
-            if ptr.is_null() {
-                None
-            } else {
-                Some(CStr::from_ptr(ptr).to_str().unwrap())
-            }
-        }
+    pub fn name(&self) -> Result<ObsString> {
+        unsafe { obs_output_get_name(self.inner) }.try_into_obs_string()
     }
 
     pub fn start(&mut self) -> bool {

--- a/src/output/ffi.rs
+++ b/src/output/ffi.rs
@@ -53,7 +53,7 @@ pub unsafe extern "C" fn create<D: Outputable>(
     settings: *mut obs_data_t,
     output: *mut obs_output_t,
 ) -> *mut c_void {
-    let settings = DataObj::from_raw(settings);
+    let settings = DataObj::from_raw(settings).unwrap();
     let mut context = CreatableOutputContext::from_raw(settings);
     let output_context = OutputContext::from_raw(output);
 
@@ -129,13 +129,13 @@ pub unsafe extern "C" fn encoded_packet<D: EncodedPacketOutput>(
 
 pub unsafe extern "C" fn update<D: UpdateOutput>(data: *mut c_void, settings: *mut obs_data_t) {
     let data: &mut DataWrapper<D> = &mut *(data as *mut DataWrapper<D>);
-    let mut settings = DataObj::from_raw(settings);
+    let mut settings = DataObj::from_raw(settings).unwrap();
     D::update(&mut data.data, &mut settings);
     forget(settings);
 }
 
 pub unsafe extern "C" fn get_defaults<D: GetDefaultsOutput>(settings: *mut obs_data_t) {
-    let mut settings = DataObj::from_raw(settings);
+    let mut settings = DataObj::from_raw(settings).unwrap();
     D::get_defaults(&mut settings);
     forget(settings);
 }

--- a/src/output/ffi.rs
+++ b/src/output/ffi.rs
@@ -1,4 +1,4 @@
-use super::{traits::*, CreatableOutputContext, OutputContext};
+use super::{traits::*, CreatableOutputContext, OutputRef};
 use crate::hotkey::{Hotkey, HotkeyCallbacks};
 use crate::{data::DataObj, wrapper::PtrWrapper};
 use obs_sys::{
@@ -53,9 +53,10 @@ pub unsafe extern "C" fn create<D: Outputable>(
     settings: *mut obs_data_t,
     output: *mut obs_output_t,
 ) -> *mut c_void {
-    let settings = DataObj::from_raw(settings).unwrap();
+    // this is later forgotten
+    let settings = DataObj::from_raw_unchecked(settings).unwrap();
     let mut context = CreatableOutputContext::from_raw(settings);
-    let output_context = OutputContext::from_raw(output);
+    let output_context = OutputRef::from_raw(output).expect("create");
 
     let data = D::create(&mut context, output_context);
     let wrapper = Box::new(DataWrapper::from(data));
@@ -129,13 +130,15 @@ pub unsafe extern "C" fn encoded_packet<D: EncodedPacketOutput>(
 
 pub unsafe extern "C" fn update<D: UpdateOutput>(data: *mut c_void, settings: *mut obs_data_t) {
     let data: &mut DataWrapper<D> = &mut *(data as *mut DataWrapper<D>);
-    let mut settings = DataObj::from_raw(settings).unwrap();
+    // this is later forgotten
+    let mut settings = DataObj::from_raw_unchecked(settings).unwrap();
     D::update(&mut data.data, &mut settings);
     forget(settings);
 }
 
 pub unsafe extern "C" fn get_defaults<D: GetDefaultsOutput>(settings: *mut obs_data_t) {
-    let mut settings = DataObj::from_raw(settings).unwrap();
+    // this is later forgotten
+    let mut settings = DataObj::from_raw_unchecked(settings).unwrap();
     D::get_defaults(&mut settings);
     forget(settings);
 }

--- a/src/output/traits.rs
+++ b/src/output/traits.rs
@@ -2,11 +2,11 @@ use obs_sys::{audio_data, encoder_packet, video_data};
 
 use crate::{prelude::DataObj, properties::Properties, string::ObsString};
 
-use super::{CreatableOutputContext, OutputContext};
+use super::{CreatableOutputContext, OutputRef};
 
 pub trait Outputable: Sized {
     fn get_id() -> ObsString;
-    fn create(context: &mut CreatableOutputContext<'_, Self>, output: OutputContext) -> Self;
+    fn create(context: &mut CreatableOutputContext<'_, Self>, output: OutputRef) -> Self;
 
     fn start(&mut self) -> bool {
         true

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -29,32 +29,32 @@ use std::{marker::PhantomData, ops::RangeBounds, os::raw::c_int};
 native_enum!(TextType, obs_text_type {
     Default => OBS_TEXT_DEFAULT,
     Password => OBS_TEXT_PASSWORD,
-    Multiline => OBS_TEXT_MULTILINE
+    Multiline => OBS_TEXT_MULTILINE,
 });
 
 native_enum!(PathType, obs_path_type {
     File => OBS_PATH_FILE,
     FileSave => OBS_PATH_FILE_SAVE,
-    Directory => OBS_PATH_DIRECTORY
+    Directory => OBS_PATH_DIRECTORY,
 });
 
 native_enum!(ComboFormat, obs_combo_format {
     Invalid => OBS_COMBO_FORMAT_INVALID,
     Int => OBS_COMBO_FORMAT_INT,
     Float => OBS_COMBO_FORMAT_FLOAT,
-    String => OBS_COMBO_FORMAT_STRING
+    String => OBS_COMBO_FORMAT_STRING,
 });
 
 native_enum!(ComboType, obs_combo_type {
     Invalid => OBS_COMBO_TYPE_INVALID,
     Editable => OBS_COMBO_TYPE_EDITABLE,
-    List => OBS_COMBO_TYPE_LIST
+    List => OBS_COMBO_TYPE_LIST,
 });
 
 native_enum!(EditableListType, obs_editable_list_type {
     Strings => OBS_EDITABLE_LIST_TYPE_STRINGS,
     Files => OBS_EDITABLE_LIST_TYPE_FILES,
-    FilesAndUrls => OBS_EDITABLE_LIST_TYPE_FILES_AND_URLS
+    FilesAndUrls => OBS_EDITABLE_LIST_TYPE_FILES_AND_URLS,
 });
 
 /// Wrapper around [`obs_properties_t`], which is used by

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -63,26 +63,12 @@ pub struct Properties {
     pointer: *mut obs_properties_t,
 }
 
-impl PtrWrapper for Properties {
-    type Pointer = obs_properties_t;
-
-    unsafe fn from_raw_unchecked(raw: *mut Self::Pointer) -> Option<Self> {
-        if raw.is_null() {
-            None
-        } else {
-            Some(Self { pointer: raw })
-        }
-    }
-
-    unsafe fn as_ptr(&self) -> *const Self::Pointer {
-        self.pointer
-    }
-
-    unsafe fn get_ref(ptr: *mut Self::Pointer) -> *mut Self::Pointer {
-        ptr
-    }
-
-    unsafe fn release(_ptr: *mut Self::Pointer) {}
+impl_ptr_wrapper! {
+    @ptr: pointer,
+    Properties,
+    obs_properties_t,
+    @identity,
+    obs_properties_destroy
 }
 
 impl Default for Properties {
@@ -132,12 +118,6 @@ impl Properties {
             );
             ListProp::from_raw(raw).expect("obs_properties_add_list")
         }
-    }
-}
-
-impl Drop for Properties {
-    fn drop(&mut self) {
-        unsafe { obs_properties_destroy(self.pointer) }
     }
 }
 

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,0 +1,27 @@
+
+pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    /// Error from OBS API
+    #[error("OBS Error: {0}")]
+    ObsError(i32),
+    /// Null Pointer
+    #[error("Null Pointer Error: {0}")]
+    NulPointer(&'static str),
+    /// Error converting string
+    #[error("Utf8 Error: {0}")]
+    Utf8Error(#[from] std::str::Utf8Error),
+    /// Error converting enum
+    #[error("Enum Out of Range: {0} {1}")]
+    EnumOutOfRange(&'static str, i64),
+}
+
+pub trait OptionExt {
+    fn null_pointer(self, msg: &'static str) -> Result<()>;
+}
+impl OptionExt for Option<()> {
+    fn null_pointer(self, msg: &'static str) -> Result<()> {
+        self.ok_or(Error::NulPointer(msg))
+    }
+}

--- a/src/result.rs
+++ b/src/result.rs
@@ -17,6 +17,9 @@ pub enum Error {
     /// Error converting enum
     #[error("Enum Out of Range: {0} {1}")]
     EnumOutOfRange(&'static str, i64),
+    /// Error converting path to str
+    #[error("Path Error: utf8")]
+    PathUtf8,
 }
 
 pub trait OptionExt {

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,4 +1,3 @@
-
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Debug, thiserror::Error)]
@@ -9,6 +8,9 @@ pub enum Error {
     /// Null Pointer
     #[error("Null Pointer Error: {0}")]
     NulPointer(&'static str),
+    /// Null Error
+    #[error("Null String Error: {0}")]
+    NulError(#[from] std::ffi::NulError),
     /// Error converting string
     #[error("Utf8 Error: {0}")]
     Utf8Error(#[from] std::str::Utf8Error),

--- a/src/source/ffi.rs
+++ b/src/source/ffi.rs
@@ -218,7 +218,7 @@ pub unsafe extern "C" fn media_get_state<D: MediaGetStateSource>(
     data: *mut std::os::raw::c_void,
 ) -> obs_media_state {
     let wrapper = &mut *(data as *mut DataWrapper<D>);
-    D::get_state(&mut wrapper.data).to_native()
+    D::get_state(&mut wrapper.data).as_raw()
 }
 
 pub unsafe extern "C" fn media_set_time<D: MediaSetTimeSource>(

--- a/src/source/ffi.rs
+++ b/src/source/ffi.rs
@@ -87,7 +87,7 @@ pub unsafe extern "C" fn create<D: Sourceable>(
     source: *mut obs_source_t,
 ) -> *mut c_void {
     let mut global = GlobalContext;
-    let settings = DataObj::from_raw(settings);
+    let settings = DataObj::from_raw(settings).unwrap();
     let mut context = CreatableSourceContext::from_raw(settings, &mut global);
     let source_context = SourceRef::from_raw(source).expect("create");
 
@@ -115,7 +115,7 @@ pub unsafe extern "C" fn destroy<D>(data: *mut c_void) {
 pub unsafe extern "C" fn update<D: UpdateSource>(data: *mut c_void, settings: *mut obs_data_t) {
     let mut global = GlobalContext;
     let data: &mut DataWrapper<D> = &mut *(data as *mut DataWrapper<D>);
-    let mut settings = DataObj::from_raw(settings);
+    let mut settings = DataObj::from_raw(settings).unwrap();
     D::update(&mut data.data, &mut settings, &mut global);
     forget(settings);
 }
@@ -252,7 +252,7 @@ impl_media!(
 );
 
 pub unsafe extern "C" fn get_defaults<D: GetDefaultsSource>(settings: *mut obs_data_t) {
-    let mut settings = DataObj::from_raw(settings);
+    let mut settings = DataObj::from_raw(settings).unwrap();
     D::get_defaults(&mut settings);
     forget(settings);
 }

--- a/src/source/ffi.rs
+++ b/src/source/ffi.rs
@@ -87,7 +87,8 @@ pub unsafe extern "C" fn create<D: Sourceable>(
     source: *mut obs_source_t,
 ) -> *mut c_void {
     let mut global = GlobalContext;
-    let settings = DataObj::from_raw(settings).unwrap();
+    // this is later forgotten
+    let settings = DataObj::from_raw_unchecked(settings).unwrap();
     let mut context = CreatableSourceContext::from_raw(settings, &mut global);
     let source_context = SourceRef::from_raw(source).expect("create");
 
@@ -115,7 +116,7 @@ pub unsafe extern "C" fn destroy<D>(data: *mut c_void) {
 pub unsafe extern "C" fn update<D: UpdateSource>(data: *mut c_void, settings: *mut obs_data_t) {
     let mut global = GlobalContext;
     let data: &mut DataWrapper<D> = &mut *(data as *mut DataWrapper<D>);
-    let mut settings = DataObj::from_raw(settings).unwrap();
+    let mut settings = DataObj::from_raw_unchecked(settings).unwrap();
     D::update(&mut data.data, &mut settings, &mut global);
     forget(settings);
 }
@@ -252,7 +253,8 @@ impl_media!(
 );
 
 pub unsafe extern "C" fn get_defaults<D: GetDefaultsSource>(settings: *mut obs_data_t) {
-    let mut settings = DataObj::from_raw(settings).unwrap();
+    // this is later forgotten
+    let mut settings = DataObj::from_raw_unchecked(settings).unwrap();
     D::get_defaults(&mut settings);
     forget(settings);
 }

--- a/src/source/ffi.rs
+++ b/src/source/ffi.rs
@@ -1,5 +1,5 @@
 use super::context::{CreatableSourceContext, GlobalContext, VideoRenderContext};
-use super::{traits::*, SourceContext};
+use super::{traits::*, SourceRef};
 use super::{EnumActiveContext, EnumAllContext};
 use crate::media::{audio::AudioDataContext, video::VideoDataSourceContext};
 use crate::{
@@ -89,7 +89,7 @@ pub unsafe extern "C" fn create<D: Sourceable>(
     let mut global = GlobalContext;
     let settings = DataObj::from_raw(settings);
     let mut context = CreatableSourceContext::from_raw(settings, &mut global);
-    let source_context = SourceContext::from_raw(source);
+    let source_context = SourceRef::from_raw(source).expect("create");
 
     let data = D::create(&mut context, source_context);
 

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -131,51 +131,12 @@ impl std::fmt::Debug for SourceRef {
     }
 }
 
-// impl PtrWrapper for SourceRef {
-//     type Pointer = obs_source_t;
-
-//     fn as_ptr(&self) -> *const Self::Pointer {
-//         self.inner
-//     }
-
-
-//     unsafe fn from_raw(raw: *mut Self::Pointer) -> Self {
-//         todo!()
-//     }
-// }
-
-impl SourceRef {
-    /// # Safety
-    ///
-    /// Must call with a valid pointer.
-    pub fn from_raw(source: *mut obs_source_t) -> Option<Self> {
-        unsafe { Self::from_raw_unchecked(obs_source_get_ref(source)) }
-    }
-
-    pub unsafe fn from_raw_unchecked(source: *mut obs_source_t) -> Option<Self> {
-        if source.is_null() {
-            None
-        } else {
-            Some(Self { inner: source })
-        }
-    }
-
-    pub unsafe fn as_raw(&self) -> *mut obs_source_t {
-        self.inner
-    }
-}
-
-impl Clone for SourceRef {
-    fn clone(&self) -> Self {
-        Self::from_raw(self.inner).expect("clone")
-    }
-}
-
-impl Drop for SourceRef {
-    fn drop(&mut self) {
-        unsafe { obs_source_release(self.inner) }
-    }
-}
+impl_ptr_wrapper!(
+    SourceRef,
+    obs_source_t,
+    obs_source_get_ref,
+    obs_source_release
+);
 
 impl SourceRef {
     /// Run a function on the next source in the filter chain.

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -2,6 +2,7 @@ use paste::item;
 
 pub mod context;
 mod ffi;
+pub mod scene;
 pub mod traits;
 
 use crate::{

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -133,6 +133,7 @@ impl std::fmt::Debug for SourceRef {
 }
 
 impl_ptr_wrapper!(
+    @ptr: inner,
     SourceRef,
     obs_source_t,
     obs_source_get_ref,

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -131,6 +131,19 @@ impl std::fmt::Debug for SourceRef {
     }
 }
 
+// impl PtrWrapper for SourceRef {
+//     type Pointer = obs_source_t;
+
+//     fn as_ptr(&self) -> *const Self::Pointer {
+//         self.inner
+//     }
+
+
+//     unsafe fn from_raw(raw: *mut Self::Pointer) -> Self {
+//         todo!()
+//     }
+// }
+
 impl SourceRef {
     /// # Safety
     ///
@@ -145,6 +158,10 @@ impl SourceRef {
         } else {
             Some(Self { inner: source })
         }
+    }
+
+    pub unsafe fn as_raw(&self) -> *mut obs_source_t {
+        self.inner
     }
 }
 

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -36,8 +36,8 @@ use obs_sys::{
     obs_source_set_name, obs_source_showing, obs_source_skip_video_filter, obs_source_t,
     obs_source_type, obs_source_type_OBS_SOURCE_TYPE_FILTER, obs_source_type_OBS_SOURCE_TYPE_INPUT,
     obs_source_type_OBS_SOURCE_TYPE_SCENE, obs_source_type_OBS_SOURCE_TYPE_TRANSITION,
-    obs_source_update, obs_text_type, OBS_SOURCE_AUDIO, OBS_SOURCE_CONTROLLABLE_MEDIA,
-    OBS_SOURCE_INTERACTION, OBS_SOURCE_VIDEO,
+    obs_source_update, OBS_SOURCE_AUDIO, OBS_SOURCE_CONTROLLABLE_MEDIA, OBS_SOURCE_INTERACTION,
+    OBS_SOURCE_VIDEO,
 };
 
 use super::{
@@ -53,7 +53,7 @@ use std::{ffi::CString, marker::PhantomData};
 native_enum!(MouseButton, obs_mouse_button_type {
     Left => MOUSE_LEFT,
     Middle => MOUSE_MIDDLE,
-    Right => MOUSE_RIGHT
+    Right => MOUSE_RIGHT,
 });
 
 native_enum!(Icon, obs_icon_type {
@@ -70,7 +70,7 @@ native_enum!(Icon, obs_icon_type {
     Text => OBS_ICON_TYPE_TEXT,
     Media => OBS_ICON_TYPE_MEDIA,
     Browser => OBS_ICON_TYPE_BROWSER,
-    Custom => OBS_ICON_TYPE_CUSTOM
+    Custom => OBS_ICON_TYPE_CUSTOM,
 });
 
 /// OBS source type
@@ -253,7 +253,7 @@ impl SourceRef {
 
     pub fn media_state(&self) -> MediaState {
         let ret = unsafe { obs_source_media_get_state(self.inner) };
-        MediaState::from_native(ret).expect("Invalid media state value")
+        MediaState::from_raw(ret).expect("Invalid media state value")
     }
 
     pub fn media_started(&mut self) {

--- a/src/source/mod.rs
+++ b/src/source/mod.rs
@@ -125,6 +125,7 @@ impl SourceRef {
     pub fn do_with_target<F: FnOnce(&mut SourceRef)>(&mut self, func: F) {
         unsafe {
             if let Ok(SourceType::Filter) = SourceType::from_raw(obs_source_get_type(self.inner)) {
+                // doc says "Does not increment the reference."
                 let target = obs_filter_get_target(self.inner);
                 if let Some(mut context) = SourceRef::from_raw(target) {
                     func(&mut context);

--- a/src/source/scene.rs
+++ b/src/source/scene.rs
@@ -23,7 +23,7 @@ impl std::fmt::Debug for SceneRef {
     }
 }
 
-impl_ptr_wrapper!(SceneRef, obs_scene_t, obs_scene_get_ref, obs_scene_release);
+impl_ptr_wrapper!(@ptr: inner, SceneRef, obs_scene_t, obs_scene_get_ref, obs_scene_release);
 
 impl SceneRef {
     pub fn name(&self) -> Result<ObsString> {
@@ -53,15 +53,11 @@ pub struct SceneItemRef {
     inner: *mut obs_sceneitem_t,
 }
 
-unsafe fn scene_item_get_ref(ptr: *mut obs_sceneitem_t) -> *mut obs_sceneitem_t {
-    obs_sceneitem_addref(ptr);
-    ptr
-}
-
 impl_ptr_wrapper!(
+    @ptr: inner,
     SceneItemRef,
     obs_sceneitem_t,
-    scene_item_get_ref,
+    @addref: obs_sceneitem_addref,
     obs_sceneitem_release
 );
 

--- a/src/source/scene.rs
+++ b/src/source/scene.rs
@@ -55,13 +55,15 @@ pub struct SceneItemRef {
     inner: *mut obs_sceneitem_t,
 }
 
+unsafe fn scene_item_get_ref(ptr: *mut obs_sceneitem_t) -> *mut obs_sceneitem_t {
+    obs_sceneitem_addref(ptr);
+    ptr
+}
+
 impl_ptr_wrapper!(
     SceneItemRef,
     obs_sceneitem_t,
-    |ptr| {
-        obs_sceneitem_addref(ptr);
-        ptr
-    },
+    scene_item_get_ref,
     obs_sceneitem_release
 );
 

--- a/src/source/scene.rs
+++ b/src/source/scene.rs
@@ -1,0 +1,72 @@
+use crate::{
+    source::SourceRef,
+    string::{DisplayExt as _, ObsString},
+    wrapper::PtrWrapper,
+};
+use obs_sys::{
+    obs_scene_add, obs_scene_get_ref, obs_scene_get_source, obs_scene_release, obs_scene_t,
+    obs_sceneitem_addref, obs_sceneitem_release, obs_sceneitem_t, obs_sceneitem_visible,
+};
+
+use super::Result;
+
+pub struct SceneRef {
+    inner: *mut obs_scene_t,
+}
+
+impl std::fmt::Debug for SceneRef {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_tuple("SceneRef")
+            .field(&self.name().display())
+            .field(&self.inner)
+            .finish()
+    }
+}
+
+impl_ptr_wrapper!(SceneRef, obs_scene_t, obs_scene_get_ref, obs_scene_release);
+
+impl SceneRef {
+    pub fn name(&self) -> Result<ObsString> {
+        self.as_source().name()
+    }
+
+    pub fn as_source(&self) -> SourceRef {
+        let ptr = unsafe {
+            // as doc said "The scene’s source. Does not increment the reference"
+            // we should manually add_ref for it
+            obs_scene_get_source(self.inner)
+        };
+        SourceRef::from_raw(ptr).expect("obs_scene_get_source")
+    }
+
+    pub fn add_source(&self, source: SourceRef) -> SceneItemRef {
+        let ptr = unsafe {
+            let ptr = obs_scene_add(self.inner, source.as_ptr_mut());
+            // add ref for source, Docs said "A new scene item for a source within a scene.  Does not
+            // increment the reference"
+            obs_sceneitem_addref(ptr);
+            ptr
+        };
+        SceneItemRef::from_raw(ptr).expect("obs_scene_add")
+    }
+}
+
+pub struct SceneItemRef {
+    inner: *mut obs_sceneitem_t,
+}
+
+impl_ptr_wrapper!(
+    SceneItemRef,
+    obs_sceneitem_t,
+    |ptr| {
+        obs_sceneitem_addref(ptr);
+        ptr
+    },
+    obs_sceneitem_release
+);
+
+impl SceneItemRef {
+    pub fn visible(&self) -> bool {
+        unsafe { obs_sceneitem_visible(self.inner) }
+    }
+}

--- a/src/source/scene.rs
+++ b/src/source/scene.rs
@@ -41,11 +41,9 @@ impl SceneRef {
 
     pub fn add_source(&self, source: SourceRef) -> SceneItemRef {
         let ptr = unsafe {
-            let ptr = obs_scene_add(self.inner, source.as_ptr_mut());
             // add ref for source, Docs said "A new scene item for a source within a scene.  Does not
             // increment the reference"
-            obs_sceneitem_addref(ptr);
-            ptr
+            obs_scene_add(self.inner, source.as_ptr_mut())
         };
         SceneItemRef::from_raw(ptr).expect("obs_scene_add")
     }

--- a/src/source/traits.rs
+++ b/src/source/traits.rs
@@ -1,7 +1,7 @@
 use obs_sys::{obs_key_event, obs_mouse_event};
 
 use super::context::{CreatableSourceContext, GlobalContext, VideoRenderContext};
-use super::{EnumActiveContext, EnumAllContext, SourceContext, SourceType};
+use super::{EnumActiveContext, EnumAllContext, SourceRef, SourceType};
 use crate::data::DataObj;
 use crate::media::state::MediaState;
 use crate::media::{audio::AudioDataContext, video::VideoDataSourceContext};
@@ -11,7 +11,7 @@ use crate::string::ObsString;
 pub trait Sourceable: Sized {
     fn get_id() -> ObsString;
     fn get_type() -> SourceType;
-    fn create(create: &mut CreatableSourceContext<Self>, source: SourceContext) -> Self;
+    fn create(create: &mut CreatableSourceContext<Self>, source: SourceRef) -> Self;
 }
 
 macro_rules! simple_trait {

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,9 +1,10 @@
 use std::{
     ffi::{CStr, CString},
+    path::Path,
     ptr::null,
 };
 
-use crate::Result;
+use crate::{Error, Result};
 
 #[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub enum ObsString {
@@ -63,6 +64,13 @@ impl TryIntoObsString for &str {
 impl TryIntoObsString for String {
     fn try_into_obs_string(self) -> Result<ObsString> {
         Ok(ObsString::Dynamic(CString::new(self)?))
+    }
+}
+impl TryIntoObsString for &Path {
+    fn try_into_obs_string(self) -> Result<ObsString> {
+        Ok(ObsString::Dynamic(CString::new(
+            self.to_str().ok_or(Error::PathUtf8)?,
+        )?))
     }
 }
 impl TryIntoObsString for *const std::os::raw::c_char {

--- a/src/string.rs
+++ b/src/string.rs
@@ -66,6 +66,7 @@ impl TryIntoObsString for String {
     }
 }
 impl TryIntoObsString for *const std::os::raw::c_char {
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     fn try_into_obs_string(self) -> Result<ObsString> {
         if self.is_null() {
             return Err(crate::Error::NulPointer("ObsString"));
@@ -89,8 +90,8 @@ impl<E> DisplayExt for Result<ObsString, E> {}
 impl std::fmt::Display for DisplayStr<'_, ObsString> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            DisplayStr(ObsString::Static(s)) => return write!(f, "{}", &s[..s.len() - 1]),
-            DisplayStr(ObsString::Dynamic(s)) => return write!(f, "{}", s.to_string_lossy()),
+            DisplayStr(ObsString::Static(s)) => write!(f, "{}", &s[..s.len() - 1]),
+            DisplayStr(ObsString::Dynamic(s)) => write!(f, "{}", s.to_string_lossy()),
         }
     }
 }

--- a/src/string.rs
+++ b/src/string.rs
@@ -85,7 +85,7 @@ pub trait DisplayExt: Sized {
 impl DisplayExt for ObsString {}
 impl DisplayExt for Option<ObsString> {}
 impl<'a> DisplayExt for Option<&'a ObsString> {}
-impl DisplayExt for Result<ObsString> {}
+impl<E> DisplayExt for Result<ObsString, E> {}
 impl std::fmt::Display for DisplayStr<'_, ObsString> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -122,7 +122,7 @@ where
         }
     }
 }
-impl<'a, T: DisplayExt> std::fmt::Debug for DisplayStr<'a, Result<T>>
+impl<'a, T: DisplayExt, E> std::fmt::Debug for DisplayStr<'a, Result<T, E>>
 where
     DisplayStr<'a, T>: std::fmt::Debug,
 {

--- a/src/string.rs
+++ b/src/string.rs
@@ -1,4 +1,9 @@
-use std::{ffi::CString, ptr::null};
+use std::{
+    ffi::{CStr, CString},
+    ptr::null,
+};
+
+use crate::Result;
 
 #[derive(Debug, Eq, PartialEq, Hash, Clone)]
 pub enum ObsString {
@@ -44,4 +49,87 @@ macro_rules! obs_string {
     ($e:expr) => {
         unsafe { $crate::string::ObsString::from_nul_terminted_str(concat!($e, "\0")) }
     };
+}
+
+pub trait TryIntoObsString {
+    fn try_into_obs_string(self) -> Result<ObsString>;
+}
+
+impl TryIntoObsString for &str {
+    fn try_into_obs_string(self) -> Result<ObsString> {
+        Ok(ObsString::Dynamic(CString::new(self)?))
+    }
+}
+impl TryIntoObsString for String {
+    fn try_into_obs_string(self) -> Result<ObsString> {
+        Ok(ObsString::Dynamic(CString::new(self)?))
+    }
+}
+impl TryIntoObsString for *const std::os::raw::c_char {
+    fn try_into_obs_string(self) -> Result<ObsString> {
+        if self.is_null() {
+            return Err(crate::Error::NulPointer("ObsString"));
+        }
+        Ok(ObsString::Dynamic(
+            unsafe { CStr::from_ptr(self) }.to_owned(),
+        ))
+    }
+}
+
+pub struct DisplayStr<'a, T>(&'a T);
+pub trait DisplayExt: Sized {
+    fn display(&self) -> DisplayStr<'_, Self> {
+        DisplayStr(self)
+    }
+}
+impl DisplayExt for ObsString {}
+impl DisplayExt for Option<ObsString> {}
+impl<'a> DisplayExt for Option<&'a ObsString> {}
+impl DisplayExt for Result<ObsString> {}
+impl std::fmt::Display for DisplayStr<'_, ObsString> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DisplayStr(ObsString::Static(s)) => return write!(f, "{}", &s[..s.len() - 1]),
+            DisplayStr(ObsString::Dynamic(s)) => return write!(f, "{}", s.to_string_lossy()),
+        }
+    }
+}
+impl std::fmt::Debug for DisplayStr<'_, ObsString> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self.to_string())
+    }
+}
+
+impl<'a, T: DisplayExt> std::fmt::Display for DisplayStr<'a, Option<T>>
+where
+    DisplayStr<'a, T>: std::fmt::Display,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            Some(s) => write!(f, "{}", s.display()),
+            None => write!(f, "<null>"),
+        }
+    }
+}
+impl<'a, T: DisplayExt> std::fmt::Debug for DisplayStr<'a, Option<T>>
+where
+    DisplayStr<'a, T>: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            Some(s) => write!(f, "{:?}", s.display()),
+            None => write!(f, "None"),
+        }
+    }
+}
+impl<'a, T: DisplayExt> std::fmt::Debug for DisplayStr<'a, Result<T>>
+where
+    DisplayStr<'a, T>: std::fmt::Debug,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0 {
+            Ok(s) => write!(f, "{:?}", s.display()),
+            _ => write!(f, "Error"),
+        }
+    }
 }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -114,7 +114,7 @@ macro_rules! impl_ptr_wrapper {
         }
     };
     (@__impl.trait.wrapper $ref:ty, $ptr:ty, $get_ref:item, $release:expr) => {
-        impl PtrWrapper for $ref {
+        impl $crate::wrapper::PtrWrapper for $ref {
             type Pointer = $ptr;
 
             unsafe fn from_raw_unchecked(raw: *mut Self::Pointer) -> Option<Self> {
@@ -148,6 +148,7 @@ macro_rules! impl_ptr_wrapper {
     (@__impl.trait.drop $ref:ty, $ptr:ty) => {
         impl Drop for $ref {
             fn drop(&mut self) {
+                use $crate::wrapper::PtrWrapper;
                 unsafe { Self::release(self.as_ptr_mut()) }
             }
         }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -8,8 +8,8 @@ pub trait PtrWrapperInternal: PtrWrapper {
     unsafe fn new_internal(ptr: *mut Self::Pointer) -> Self;
     /// # Safety
     ///
-    /// This function should not be called directly, use `from_raw` and
-    /// `from_raw_unchecked` instead.
+    /// This function should not be called directly, use `as_ptr`,
+    /// `as_ptr_mut` and `into_raw` instead.
     unsafe fn get_internal(&self) -> *mut Self::Pointer;
 }
 

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -3,14 +3,18 @@ use std::mem::forget;
 pub trait PtrWrapper: Sized {
     type Pointer;
 
+    /// # Safety
+    ///
+    /// This function called extern C api, and should not be called directly.
     unsafe fn get_ref(ptr: *mut Self::Pointer) -> *mut Self::Pointer;
+
+    /// # Safety
+    ///
+    /// This function called extern C api, and should not be called directly.
     unsafe fn release(ptr: *mut Self::Pointer);
 
     /// Wraps the pointer into a **owned** wrapper.
-    ///
-    /// # Safety
-    ///
-    /// Pointer must be valid.
+    #[allow(clippy::not_unsafe_ptr_arg_deref)]
     fn from_raw(raw: *mut Self::Pointer) -> Option<Self> {
         unsafe { Self::from_raw_unchecked(Self::get_ref(raw)) }
     }
@@ -23,6 +27,11 @@ pub trait PtrWrapper: Sized {
     unsafe fn from_raw_unchecked(raw: *mut Self::Pointer) -> Option<Self>;
 
     /// Returns the inner pointer.
+    ///
+    /// # Safety
+    ///
+    /// This function would return a pointer not managed, should only called
+    /// when interacting with extern C api.
     unsafe fn as_ptr(&self) -> *const Self::Pointer;
 
     /// Consumes the wrapper and transfers ownershop to the pointer
@@ -35,6 +44,11 @@ pub trait PtrWrapper: Sized {
     }
 
     /// Returns the inner pointer (mutable version).
+    ///
+    /// # Safety
+    ///
+    /// This function would return a pointer not managed, should only called
+    /// when interacting with extern C api.
     unsafe fn as_ptr_mut(&self) -> *mut Self::Pointer {
         self.as_ptr() as *mut _
     }

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -1,5 +1,18 @@
 use std::mem::forget;
 
+pub trait PtrWrapperInternal: PtrWrapper {
+    /// # Safety
+    ///
+    /// This function should not be called directly, use `from_raw` and
+    /// `from_raw_unchecked` instead.
+    unsafe fn new_internal(ptr: *mut Self::Pointer) -> Self;
+    /// # Safety
+    ///
+    /// This function should not be called directly, use `from_raw` and
+    /// `from_raw_unchecked` instead.
+    unsafe fn get_internal(&self) -> *mut Self::Pointer;
+}
+
 pub trait PtrWrapper: Sized {
     type Pointer;
 
@@ -55,40 +68,87 @@ pub trait PtrWrapper: Sized {
 }
 
 macro_rules! impl_ptr_wrapper {
-    ($ref:ident, $ptr:ty, $get_ref:expr, $release:expr) => {
+    (@ptr: $field:ident, $ref:ty, $($tt:tt)*) => {
+        impl_ptr_wrapper!(@__impl.trait.internal $ref, $field);
+        impl_ptr_wrapper!($ref, $($tt)*);
+    };
+    ($ref:ty, $ptr:ty, @identity, $release:expr) => {
+        impl_ptr_wrapper!(@__impl.trait.wrapper $ref, $ptr, impl_ptr_wrapper!{@__impl.fn.id}, $release);
+        // when get_ref is `@identity`, no `Clone implemented`
+        impl_ptr_wrapper!(@__impl.trait.drop $ref, $ptr);
+    };
+    ($ref:ty, $ptr:ty, $get_ref:expr, $release:expr) => {
+        impl_ptr_wrapper!(@__impl.trait.wrapper $ref, $ptr, impl_ptr_wrapper!{@__impl.fn.get_ref $get_ref}, $release);
+        impl_ptr_wrapper!(@__impl.trait.clone $ref, $ptr);
+        impl_ptr_wrapper!(@__impl.trait.drop $ref, $ptr);
+    };
+
+    ($ref:ty, $ptr:ty, @addref: $add_ref:expr, $release:expr) => {
+        impl_ptr_wrapper!(@__impl.trait.wrapper $ref, $ptr, impl_ptr_wrapper!{@__impl.fn.add_ref $add_ref}, $release);
+        impl_ptr_wrapper!(@__impl.trait.clone $ref, $ptr);
+        impl_ptr_wrapper!(@__impl.trait.drop $ref, $ptr);
+    };
+    (@__impl.fn.get_ref $get_ref:expr) => {
+        unsafe fn get_ref(ptr: *mut Self::Pointer) -> *mut Self::Pointer {
+            unsafe { $get_ref(ptr) }
+        }
+    };
+    (@__impl.fn.add_ref $add_ref:expr) => {
+        unsafe fn get_ref(ptr: *mut Self::Pointer) -> *mut Self::Pointer {
+            unsafe { $add_ref(ptr); ptr }
+        }
+    };
+    (@__impl.fn.id) => {
+        unsafe fn get_ref(ptr: *mut Self::Pointer) -> *mut Self::Pointer {
+            ptr
+        }
+    };
+    (@__impl.trait.internal $ref:ty, $field:ident) => {
+        impl $crate::wrapper::PtrWrapperInternal for $ref {
+            unsafe fn new_internal(ptr: *mut Self::Pointer) -> Self {
+                Self { $field: ptr }
+            }
+            unsafe fn get_internal(&self) -> *mut Self::Pointer {
+                self.$field
+            }
+        }
+    };
+    (@__impl.trait.wrapper $ref:ty, $ptr:ty, $get_ref:item, $release:expr) => {
         impl PtrWrapper for $ref {
             type Pointer = $ptr;
 
-            unsafe fn get_ref(ptr: *mut Self::Pointer) -> *mut Self::Pointer {
-                unsafe { $get_ref(ptr) }
+            unsafe fn from_raw_unchecked(raw: *mut Self::Pointer) -> Option<Self> {
+                use $crate::wrapper::PtrWrapperInternal;
+                if raw.is_null() {
+                    None
+                } else {
+                    Some(Self::new_internal(raw))
+                }
             }
+
+            $get_ref
 
             unsafe fn release(ptr: *mut Self::Pointer) {
                 unsafe { $release(ptr) }
             }
 
-            unsafe fn from_raw_unchecked(raw: *mut Self::Pointer) -> Option<Self> {
-                if raw.is_null() {
-                    None
-                } else {
-                    Some(Self { inner: raw })
-                }
-            }
-
             unsafe fn as_ptr(&self) -> *const Self::Pointer {
-                self.inner
+                use $crate::wrapper::PtrWrapperInternal;
+                self.get_internal()
             }
         }
-
+    };
+    (@__impl.trait.clone $ref:ty, $ptr:ty) => {
         impl Clone for $ref {
             fn clone(&self) -> Self {
-                Self::from_raw(self.inner).expect("clone")
+                Self::from_raw(unsafe { self.as_ptr_mut() }).expect("clone")
             }
         }
-
+    };
+    (@__impl.trait.drop $ref:ty, $ptr:ty) => {
         impl Drop for $ref {
             fn drop(&mut self) {
-                unsafe { Self::release(self.inner) }
+                unsafe { Self::release(self.as_ptr_mut()) }
             }
         }
     };

--- a/src/wrapper.rs
+++ b/src/wrapper.rs
@@ -2,27 +2,80 @@ use std::mem::forget;
 
 pub trait PtrWrapper: Sized {
     type Pointer;
+
+    unsafe fn get_ref(ptr: *mut Self::Pointer) -> *mut Self::Pointer;
+    unsafe fn release(ptr: *mut Self::Pointer);
+
     /// Wraps the pointer into a **owned** wrapper.
     ///
     /// # Safety
     ///
     /// Pointer must be valid.
-    unsafe fn from_raw(raw: *mut Self::Pointer) -> Self;
+    fn from_raw(raw: *mut Self::Pointer) -> Option<Self> {
+        unsafe { Self::from_raw_unchecked(Self::get_ref(raw)) }
+    }
+
+    /// Wraps a **owned** pointer into wrapper.
+    ///
+    /// # Safety
+    ///
+    /// You have to make sure you owned the pointer
+    unsafe fn from_raw_unchecked(raw: *mut Self::Pointer) -> Option<Self>;
 
     /// Returns the inner pointer.
-    fn as_ptr(&self) -> *const Self::Pointer;
+    unsafe fn as_ptr(&self) -> *const Self::Pointer;
 
     /// Consumes the wrapper and transfers ownershop to the pointer
     ///
     /// This does **NOT** drop the wrapper internally.
-    fn into_raw(mut self) -> *mut Self::Pointer {
-        let raw = self.as_ptr_mut();
+    fn into_raw(self) -> *mut Self::Pointer {
+        let raw = unsafe { self.as_ptr_mut() };
         forget(self);
         raw
     }
 
     /// Returns the inner pointer (mutable version).
-    fn as_ptr_mut(&mut self) -> *mut Self::Pointer {
+    unsafe fn as_ptr_mut(&self) -> *mut Self::Pointer {
         self.as_ptr() as *mut _
     }
+}
+
+macro_rules! impl_ptr_wrapper {
+    ($ref:ident, $ptr:ty, $get_ref:expr, $release:expr) => {
+        impl PtrWrapper for $ref {
+            type Pointer = $ptr;
+
+            unsafe fn get_ref(ptr: *mut Self::Pointer) -> *mut Self::Pointer {
+                unsafe { $get_ref(ptr) }
+            }
+
+            unsafe fn release(ptr: *mut Self::Pointer) {
+                unsafe { $release(ptr) }
+            }
+
+            unsafe fn from_raw_unchecked(raw: *mut Self::Pointer) -> Option<Self> {
+                if raw.is_null() {
+                    None
+                } else {
+                    Some(Self { inner: raw })
+                }
+            }
+
+            unsafe fn as_ptr(&self) -> *const Self::Pointer {
+                self.inner
+            }
+        }
+
+        impl Clone for $ref {
+            fn clone(&self) -> Self {
+                Self::from_raw(self.inner).expect("clone")
+            }
+        }
+
+        impl Drop for $ref {
+            fn drop(&mut self) {
+                unsafe { Self::release(self.inner) }
+            }
+        }
+    };
 }


### PR DESCRIPTION
1. we have `from_raw` and `from_raw_unchecked`
    * `from_raw` for object own/managed in C, a temporary pointer is returned (e.g. `obs_filter_get_target`).
    * `from_raw_unchecked` for object own/managed in Rust, will not `addref` the pointer, in order to handle with thing like `obs_data_create()`.
    * now `DataObj<'_>`, `DataArray<'_>`, `Properties` are `impl_ptr_wrapper` with no Clone
    * `DisplayRef`, `SourceRef`, `OutputRef`, `SceneRef`, `SceneItemRef` are `impl_ptr_wrapper`
    * `ModuleRef` is special since it has no release.
3. now `from_raw` and `from_raw_uncheced` would return `Option<Self>` and convert to nullptr to `None`.
4. rename `SourceContext` to `SourceRef`, `ModuleContext` to `ModuleRef`, in order to keep consistence with other `AudioRef`, `VideoRef`. Now `Context` means state in rust and `Ref` means a pointer and the state in C. (we could add alias in order to keep backward compatibility)
5. add `.display()` to `ObsString`
6. add `SceneRef` and `DisplayRef` for corresponding `obs_scene_t` and `obs_display_t`.
7. make existing declared using macro `native_enum`